### PR TITLE
Use uv for dependency management and add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: sync run
+
+sync:
+	uv sync
+
+run:
+	uv run run_pipeline.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # dark-life
-Tall tails
+
+Automation for dark storytelling video pipeline.
+
+## Development
+
+This project uses [uv](https://github.com/astral-sh/uv) for dependency management.
+
+To install dependencies:
+
+```bash
+uv sync
+```
+
+Run the pipeline:
+
+```bash
+uv run run_pipeline.py
+```
+
+You can also use the provided `Makefile`:
+
+```bash
+make sync
+make run
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,10 @@ generate-subtitles = "scripts.generate_subtitles:app"
 create-video = "scripts.create_video:app"
 update-dashboard = "scripts.update_dashboard:app"
 run-pipeline = "run_pipeline:app"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv]
+package = true


### PR DESCRIPTION
## Summary
- configure project for uv with build-system metadata and uv settings
- document uv usage and add Makefile convenience commands

## Testing
- `make sync` *(fails: Failed to fetch: `https://pypi.org/simple/jinja2/`)*
- `uv run run_pipeline.py --help` *(fails: Failed to fetch: `https://pypi.org/simple/requests/`)*

------
https://chatgpt.com/codex/tasks/task_e_689518800d70833287bc8bd4c039a703