### PR TITLE
Verify Pexels API key before building request headers

### DIFF
--- a/scripts/fetch_visuals.py
+++ b/scripts/fetch_visuals.py
@@ -7,9 +7,10 @@ from pathlib import Path
 PEXELS_API_KEY = os.getenv("PEXELS_API_KEY")
 PEXELS_SEARCH_URL = "https://api.pexels.com/v1/search"
 
-HEADERS = {
-    "Authorization": PEXELS_API_KEY
-}
+if not PEXELS_API_KEY:
+    raise RuntimeError("PEXELS_API_KEY environment variable is required")
+
+HEADERS = {"Authorization": PEXELS_API_KEY}
 
 def extract_keywords_from_story(filepath):
     """Extract nouns or key phrases from the story text (simple heuristic)."""
@@ -46,9 +47,6 @@ if __name__ == "__main__":
     parser.add_argument("--out", default="content/visuals", help="Directory to save images")
 
     args = parser.parse_args()
-
-    if not PEXELS_API_KEY:
-        raise RuntimeError("Set PEXELS_API_KEY in environment")
 
     keywords = extract_keywords_from_story(args.story)
     print(f"Extracted keywords: {keywords}")


### PR DESCRIPTION
## Summary
- Ensure `fetch_visuals` validates the Pexels API key before use and builds request headers only when the key exists

## Testing
- `PEXELS_API_KEY=foo python -m py_compile scripts/fetch_visuals.py`
- `PEXELS_API_KEY=foo python scripts/fetch_visuals.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68951bf3082c83329c239248e61a58f9