### PR TITLE
Add dotenv support with sample environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ You can also use the provided `Makefile`:
 make sync
 make run
 ```
+
+## Configuration
+
+Copy `sample.env` to `.env` and fill in the required API keys. The project uses `python-dotenv` to load these values automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydub",
     "jinja2",
     "python-frontmatter",
+    "python-dotenv",
 ]
 
 [project.scripts]

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -6,7 +6,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
 import typer
+
+load_dotenv()
 
 app = typer.Typer(add_completion=False)
 

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,7 @@
+# Copy to .env and replace placeholders with your own credentials
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USER_AGENT=dark-life-script/0.1 by your_username
+PEXELS_API_KEY=your_pexels_api_key
+ELEVENLABS_API_KEY=your_elevenlabs_api_key
+OPENAI_API_KEY=your_openai_api_key

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,7 @@
+
+"""Utility initialisation for scripts package."""
+
+from dotenv import load_dotenv
+
+
+load_dotenv()

--- a/scripts/fetch_reddit.py
+++ b/scripts/fetch_reddit.py
@@ -7,8 +7,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict
 
+from dotenv import load_dotenv
 import typer
 import requests
+
+load_dotenv()
 
 try:
     import praw

--- a/scripts/fetch_visuals.py
+++ b/scripts/fetch_visuals.py
@@ -4,6 +4,10 @@ import requests
 import frontmatter
 from pathlib import Path
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 PEXELS_API_KEY = os.getenv("PEXELS_API_KEY")
 PEXELS_SEARCH_URL = "https://api.pexels.com/v1/search"
 

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "praw" },
     { name = "pydub" },
+    { name = "python-dotenv" },
     { name = "python-frontmatter" },
     { name = "requests" },
     { name = "typer" },
@@ -111,6 +112,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "praw" },
     { name = "pydub" },
+    { name = "python-dotenv" },
     { name = "python-frontmatter" },
     { name = "requests" },
     { name = "typer" },
@@ -258,6 +260,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- load environment variables from `.env` using python-dotenv
- document configuration and provide `sample.env` template

## Testing
- `uv run --no-sync scripts/fetch_reddit.py --help`
- `uv run --no-sync run_pipeline.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6895201fe06c83328335d6dffe0a5a70