### PR TITLE
Add uv init target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
-.PHONY: sync run
+.PHONY: init sync run
+
+VENV_DIR := .venv
+
+init:
+	@command -v uv >/dev/null 2>&1 || { \
+		echo "uv is required but not installed. See https://github.com/astral-sh/uv"; \
+		exit 1; \
+	}
+	@[ -d $(VENV_DIR) ] || uv venv $(VENV_DIR)
+	uv sync
+	@echo "Virtual environment ready. Activate with: . $(VENV_DIR)/bin/activate"
 
 sync:
 	uv sync

--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ Automation for dark storytelling video pipeline.
 
 This project uses [uv](https://github.com/astral-sh/uv) for dependency management.
 
-To install dependencies:
+To set up the project and install dependencies:
+
+```bash
+make init
+```
+
+This will create a local virtual environment (if needed) and install dependencies via uv.
+
+You can also call uv directly:
 
 ```bash
 uv sync
@@ -21,8 +29,8 @@ uv run run_pipeline.py
 You can also use the provided `Makefile`:
 
 ```bash
-make sync
-make run
+make init   # create venv and install dependencies
+make run    # run the pipeline
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary
- add `init` make target to bootstrap uv environment
- document new `make init` usage in README

## Testing
- `make init` *(fails: Multiple top-level packages discovered in a flat-layout)*

------
https://chatgpt.com/codex/tasks/task_e_6895227c051c8332bc378862019dc683