### PR TITLE
Fix packaging for successful `make init`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Automation for dark storytelling video pipeline"
 authors = [{name = "AutoGen", email = "autogen@example.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "MIT"
 dependencies = [
     "praw",
     "requests",
@@ -27,6 +27,12 @@ run-pipeline = "run_pipeline:app"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["run_pipeline"]
+
+[tool.setuptools.packages.find]
+include = ["scripts"]
 
 [tool.uv]
 package = true


### PR DESCRIPTION
## Summary
- configure setuptools to only include scripts package and run_pipeline module
- update license field format to avoid deprecation warning

## Testing
- `make init`

------
https://chatgpt.com/codex/tasks/task_e_6895281840308332b38dbb5085b38537