### PR TITLE
fix: limit package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,14 @@ webapp = "webapp.main:cli"
 render-jobs = "video_renderer.render_job_runner:app"
 upload-videos = "video_uploader.cron_upload:app"
 
+[tool.setuptools]
+packages = [
+    "shared",
+    "webapp",
+    "video_renderer",
+    "video_uploader",
+]
+
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- restrict setuptools package list to project modules only

## Testing
- `pip install -e .`
- `python -m webapp.main --help`


------
https://chatgpt.com/codex/tasks/task_e_6895c1a44e1083328523192f57d915d6