### PR TITLE
Fix webapp CLI and add basic tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init sync run-webapp run-renderer run-uploader
+.PHONY: init sync test run-webapp run-renderer run-uploader
 
 VENV_DIR := .venv
 
@@ -22,3 +22,6 @@ run-renderer:
 
 run-uploader:
 	uv run python -m video_uploader.cron_upload run
+
+test:
+	uv run --with pytest pytest -q

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,15 @@
+from typer.testing import CliRunner
+from webapp.main import app, cli
+
+
+def test_index_route():
+    client = app.test_client()
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+def test_cli_run_command_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--help"])
+    assert result.exit_code == 0
+    assert "Run the Flask development server." in result.stdout

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -16,6 +16,12 @@ app = Flask(__name__, template_folder="templates", static_folder="static")
 cli = typer.Typer()
 
 
+@cli.callback()
+def main() -> None:
+    """CLI entry point for the web application."""
+    pass
+
+
 @app.route("/")
 def index():
     stories = sorted(config.STORIES_DIR.glob("*.md"))


### PR DESCRIPTION
## Summary
- ensure `run` is a subcommand by adding a Typer callback
- add tests for webapp index route and CLI help
- add a `test` target to the Makefile for running pytest via `uv`

## Testing
- `make test` *(fails: SyntaxError in shared/reddit.py)*

------
https://chatgpt.com/codex/tasks/task_e_6895e360b7508332901875cca8966c71