### PR TITLE
Use pydantic settings for shared configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "instagrapi",
     "pywhatkit",
     "yt-dlp",
+    "pydantic>=2.0",
+    "pydantic-settings>=2.0",
 ]
 
 [project.scripts]

--- a/shared/config.py
+++ b/shared/config.py
@@ -1,15 +1,29 @@
-"""Shared configuration constants."""
+"""Application configuration loaded from environment variables."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parent.parent
-CONTENT_DIR = BASE_DIR / "content"
-STORIES_DIR = CONTENT_DIR / "stories"
-AUDIO_DIR = CONTENT_DIR / "audio"
-VISUALS_DIR = CONTENT_DIR / "visuals"
-OUTPUT_DIR = BASE_DIR / "output"
-VIDEO_OUTPUT_DIR = OUTPUT_DIR / "videos"
-MANIFEST_DIR = OUTPUT_DIR / "manifest"
-RENDER_QUEUE_DIR = BASE_DIR / "render_queue"
+from dotenv import load_dotenv
+from pydantic_settings import BaseSettings
+
+load_dotenv()
+
+
+class Settings(BaseSettings):
+    """Application settings read from environment variables."""
+
+    BASE_DIR: Path = Path(__file__).resolve().parent.parent
+    CONTENT_DIR: Path = BASE_DIR / "content"
+    STORIES_DIR: Path = CONTENT_DIR / "stories"
+    AUDIO_DIR: Path = CONTENT_DIR / "audio"
+    VISUALS_DIR: Path = CONTENT_DIR / "visuals"
+    OUTPUT_DIR: Path = BASE_DIR / "output"
+    VIDEO_OUTPUT_DIR: Path = OUTPUT_DIR / "videos"
+    MANIFEST_DIR: Path = OUTPUT_DIR / "manifest"
+    RENDER_QUEUE_DIR: Path = BASE_DIR / "render_queue"
+
+
+settings = Settings()
+
+__all__ = ["Settings", "settings"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -137,6 +137,8 @@ dependencies = [
     { name = "instagrapi" },
     { name = "jinja2" },
     { name = "praw" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pydub" },
     { name = "python-dotenv" },
     { name = "python-frontmatter" },
@@ -152,6 +154,8 @@ requires-dist = [
     { name = "instagrapi" },
     { name = "jinja2" },
     { name = "praw" },
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pydub" },
     { name = "python-dotenv" },
     { name = "python-frontmatter" },
@@ -807,6 +811,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
     { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
     { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
 ]
 
 [[package]]

--- a/video_uploader/cron_upload.py
+++ b/video_uploader/cron_upload.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import typer
 
-from shared import config
+from shared.config import settings
 from . import upload_to_instagram, upload_to_tiktok
 
 app = typer.Typer(add_completion=False)
@@ -16,7 +16,7 @@ app = typer.Typer(add_completion=False)
 @app.command()
 def run(insta_user: str = "", insta_pass: str = "") -> None:
     """Upload all videos described in manifest files."""
-    for manifest in sorted(config.MANIFEST_DIR.glob("*.json")):
+    for manifest in sorted(settings.MANIFEST_DIR.glob("*.json")):
         data = json.loads(manifest.read_text())
         video = Path(data["video"])
         caption = data.get("title", "")

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -9,7 +9,7 @@ from typing import List
 from flask import Flask, redirect, render_template, request, url_for
 import typer
 
-from shared import config
+from shared.config import settings
 from shared.reddit import fetch_top_stories
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
@@ -24,7 +24,7 @@ def main() -> None:
 
 @app.route("/")
 def index():
-    stories = sorted(config.STORIES_DIR.glob("*.md"))
+    stories = sorted(settings.STORIES_DIR.glob("*.md"))
     return render_template("index.html", stories=[s.name for s in stories])
 
 
@@ -38,11 +38,11 @@ def fetch():
 def queue_story():
     story_name = request.form.get("story")
     images = request.form.get("images", "").split()
-    story_path = config.STORIES_DIR / story_name
-    image_paths: List[str] = [str((config.VISUALS_DIR / img).resolve()) for img in images if img]
+    story_path = settings.STORIES_DIR / story_name
+    image_paths: List[str] = [str((settings.VISUALS_DIR / img).resolve()) for img in images if img]
     job = {"story_path": str(story_path.resolve()), "image_paths": image_paths}
-    config.RENDER_QUEUE_DIR.mkdir(exist_ok=True)
-    job_file = config.RENDER_QUEUE_DIR / f"{story_path.stem}.json"
+    settings.RENDER_QUEUE_DIR.mkdir(exist_ok=True)
+    job_file = settings.RENDER_QUEUE_DIR / f"{story_path.stem}.json"
     job_file.write_text(json.dumps(job, indent=2))
     return redirect(url_for("index"))
 


### PR DESCRIPTION
## Summary
- replace shared config constants with a pydantic-settings model
- load environment from .env and expose singleton `settings`
- update modules to consume shared `settings` object and add pydantic dependencies

## Testing
- `uv run --with pytest pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f16bee888332a8bf20f255a8192b