### PR TITLE
Handle job failures gracefully

### DIFF
--- a/video_renderer/render_job_runner.py
+++ b/video_renderer/render_job_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -26,23 +27,41 @@ def _load_job(path: Path) -> RenderJob:
 def _process_job(job: RenderJob) -> None:
     story_id = job.story_path.stem
     # Generate voiceover and subtitles
-    voiceover.main(
-        input_dir=config.STORIES_DIR,
-        output_dir=config.CONTENT_DIR / "audio" / "voiceovers",
-    )
-    whisper_subs.main(
-        input_dir=config.CONTENT_DIR / "audio" / "voiceovers",
-        stories_dir=config.STORIES_DIR,
-    )
+    try:
+        voiceover.main(
+            input_dir=config.STORIES_DIR,
+            output_dir=config.CONTENT_DIR / "audio" / "voiceovers",
+        )
+    except Exception:  # pragma: no cover - logging side-effect
+        logging.exception("voiceover generation failed for %s", story_id)
+        return
+    try:
+        whisper_subs.main(
+            input_dir=config.CONTENT_DIR / "audio" / "voiceovers",
+            stories_dir=config.STORIES_DIR,
+        )
+    except Exception:  # pragma: no cover - logging side-effect
+        logging.exception("subtitle creation failed for %s", story_id)
+        return
     # Create video slideshow
-    create_slideshow.main(["--story_id", story_id])
+    try:
+        rc = create_slideshow.main(["--story_id", story_id])
+    except Exception:  # pragma: no cover - logging side-effect
+        logging.exception("slideshow creation crashed for %s", story_id)
+        return
+    if rc != 0:
+        logging.error("slideshow creation failed for %s with code %s", story_id, rc)
+        return
     # Write manifest
-    config.MANIFEST_DIR.mkdir(parents=True, exist_ok=True)
-    manifest = {
-        "story": story_id,
-        "video": str((config.VIDEO_OUTPUT_DIR / f"{story_id}_final.mp4").resolve()),
-    }
-    (config.MANIFEST_DIR / f"{story_id}.json").write_text(json.dumps(manifest, indent=2))
+    try:
+        config.MANIFEST_DIR.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "story": story_id,
+            "video": str((config.VIDEO_OUTPUT_DIR / f"{story_id}_final.mp4").resolve()),
+        }
+        (config.MANIFEST_DIR / f"{story_id}.json").write_text(json.dumps(manifest, indent=2))
+    except Exception:  # pragma: no cover - logging side-effect
+        logging.exception("failed to write manifest for %s", story_id)
 
 
 @app.command()
@@ -51,8 +70,12 @@ def run() -> None:
     config.RENDER_QUEUE_DIR.mkdir(exist_ok=True)
     for job_file in sorted(config.RENDER_QUEUE_DIR.glob("*.json")):
         job = _load_job(job_file)
-        _process_job(job)
-        job_file.unlink()
+        try:
+            _process_job(job)
+        except Exception:  # pragma: no cover - logging side-effect
+            logging.exception("job failed: %s", job_file)
+        finally:
+            job_file.unlink()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- Wrap render job processing steps in try/except blocks
- Log slideshow failures based on exit code and skip manifest creation
- Continue processing remaining jobs even when one fails

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f171846c8332b74b858fa8cc7990