### PR TITLE
Handle Instagram upload errors

### DIFF
--- a/video_uploader/upload_to_instagram.py
+++ b/video_uploader/upload_to_instagram.py
@@ -16,5 +16,14 @@ def upload(video: Path, caption: str, username: str, password: str) -> None:
         print("instagrapi not installed; skipping upload")
         return
     cl = Client()
-    cl.login(username, password)
-    cl.video_upload(str(video), caption)
+    try:
+        cl.login(username, password)
+    except Exception as exc:  # pragma: no cover - handled gracefully
+        print(f"Instagram login failed: {exc}")
+        return
+
+    try:
+        cl.video_upload(str(video), caption)
+    except Exception as exc:  # pragma: no cover - handled gracefully
+        print(f"Instagram upload failed: {exc}")
+        return


### PR DESCRIPTION
## Summary
- add graceful error handling for instagrapi login and upload

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'video_renderer'; No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_689613b5629c8332b7bdbc5cd5af2728