### PR TITLE
Compute subtitle timings from audio duration

### DIFF
--- a/tests/test_whisper_subs.py
+++ b/tests/test_whisper_subs.py
@@ -4,7 +4,7 @@ from pydub import AudioSegment
 from video_renderer import whisper_subs as ws
 
 
-@pytest.mark.parametrize("duration_ms", [3000, 6000])
+@pytest.mark.parametrize("duration_ms", [3000, 4500, 6000])
 def test_srt_timings_vary_with_audio_length(tmp_path, duration_ms):
     voice_dir = tmp_path / "voiceovers"
     story_dir = tmp_path / "stories"
@@ -53,3 +53,29 @@ def test_ass_timings(tmp_path):
     expected_total = ws._format_ass_time(duration_ms / 1000)
     assert dialogue[0] == f"Dialogue: 0,00:00:00.00,{expected_first_end},First."
     assert dialogue[1] == f"Dialogue: 0,{expected_first_end},{expected_total},Second."
+
+
+def test_srt_three_sentences(tmp_path):
+    voice_dir = tmp_path / "voiceovers"
+    story_dir = tmp_path / "stories"
+    voice_dir.mkdir()
+    story_dir.mkdir()
+
+    duration_ms = 4500
+    audio = AudioSegment.silent(duration=duration_ms)
+    voice_path = voice_dir / "sample.mp3"
+    audio.export(voice_path, format="mp3")
+    (story_dir / "sample.md").write_text("One. Two. Three.", encoding="utf-8")
+
+    ws.main(input_dir=voice_dir, stories_dir=story_dir, fmt="srt")
+
+    srt_path = voice_path.with_suffix(".srt")
+    lines = srt_path.read_text().splitlines()
+    timings = [l for l in lines if " --> " in l]
+    per_sentence = (duration_ms / 1000) / 3
+    first_end = ws._format_srt_time(per_sentence)
+    second_end = ws._format_srt_time(per_sentence * 2)
+    total = ws._format_srt_time(duration_ms / 1000)
+    assert timings[0] == f"00:00:00,000 --> {first_end}"
+    assert timings[1] == f"{first_end} --> {second_end}"
+    assert timings[2] == f"{second_end} --> {total}"


### PR DESCRIPTION
## Summary
- derive start/end subtitle timings from voiceover duration
- apply uniform timings for SRT and ASS output
- extend subtitle tests for varied audio lengths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896210f0d408332b9b266cf25fb8ace