### PR TITLE
feat(web): add markdown editor with autosave

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "@tanstack/react-query": "^5.84.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "marked": "^16.1.2",
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/apps/web/src/app/stories/[id]/page.tsx
+++ b/apps/web/src/app/stories/[id]/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useEffect, useMemo, useRef } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/api";
+import { marked } from "marked";
+
+interface Story {
+  id: string;
+  title: string;
+  body_md: string;
+  status: "draft" | "approved";
+}
+
+type Toast = { type: "success" | "error"; message: string };
+
+export default function StoryEditorPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { id } = params;
+  const [form, setForm] = useState<Story | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
+  const isInitial = useRef(true);
+
+  function showToast(toast: Toast) {
+    setToast(toast);
+    setTimeout(() => setToast(null), 3000);
+  }
+
+  const { data } = useQuery({
+    queryKey: ["story", id],
+    queryFn: () => apiFetch<Story>(`/stories/${id}`),
+  });
+
+  useEffect(() => {
+    if (data) {
+      setForm(data);
+    }
+  }, [data]);
+
+  const mutation = useMutation({
+    mutationFn: (patch: Partial<Story>) =>
+      apiFetch<Story>(`/stories/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      }),
+    onSuccess: () => showToast({ type: "success", message: "Saved" }),
+    onError: (err: unknown) =>
+      showToast({ type: "error", message: (err as Error).message }),
+  });
+
+  useEffect(() => {
+    if (!form) return;
+    if (isInitial.current) {
+      isInitial.current = false;
+      return;
+    }
+    const timer = setTimeout(() => {
+      mutation.mutate({
+        title: form.title,
+        body_md: form.body_md,
+        status: form.status,
+      });
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [form, mutation]);
+
+  const preview = useMemo(() => marked.parse(form?.body_md ?? ""), [form?.body_md]);
+
+  if (!form) {
+    return <p className="p-4">Loading...</p>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      {toast && (
+        <div
+          className={`fixed top-4 right-4 px-4 py-2 rounded text-white ${
+            toast.type === "success" ? "bg-green-600" : "bg-red-600"
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+      <input
+        type="text"
+        className="border p-2 w-full rounded"
+        value={form.title}
+        onChange={(e) => setForm({ ...form, title: e.target.value })}
+      />
+      <div>
+        <label className="mr-2">Status:</label>
+        <select
+          className="border rounded p-1"
+          value={form.status}
+          onChange={(e) =>
+            setForm({ ...form, status: e.target.value as Story["status"] })
+          }
+        >
+          <option value="draft">Draft</option>
+          <option value="approved">Approved</option>
+        </select>
+      </div>
+      <div className="flex gap-4">
+        <textarea
+          className="w-1/2 border p-2 rounded h-96"
+          value={form.body_md}
+          onChange={(e) => setForm({ ...form, body_md: e.target.value })}
+        />
+        <div
+          className="w-1/2 border p-2 rounded h-96 overflow-auto"
+          dangerouslySetInnerHTML={{ __html: preview }}
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      marked:
+        specifier: ^16.1.2
+        version: 16.1.2
       next:
         specifier: 15.4.6
         version: 15.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1404,6 +1407,11 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  marked@16.1.2:
+    resolution: {integrity: sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3292,6 +3300,8 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  marked@16.1.2: {}
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- add story editor page with markdown preview and status select
- debounce PATCH autosave and show toast feedback
- install marked for rendering markdown

## Testing
- `pnpm --filter web lint`


------
https://chatgpt.com/codex/tasks/task_e_6896699bd79c8332820236eb8d9b058a