### PR TITLE
feat(web): add images tab with image fetching and ordering

### DIFF
--- a/apps/web/src/app/stories/[id]/images-tab.tsx
+++ b/apps/web/src/app/stories/[id]/images-tab.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { apiFetch } from "@/lib/api";
+
+interface Asset {
+  id: string;
+  remote_url: string;
+  selected: boolean;
+  rank: number;
+}
+
+export default function ImagesTab({ storyId }: { storyId: string }) {
+  const { data, refetch } = useQuery({
+    queryKey: ["images", storyId],
+    queryFn: () => apiFetch<Asset[]>(`/stories/${storyId}/images`),
+  });
+
+  const [images, setImages] = useState<Asset[]>([]);
+  useEffect(() => {
+    if (data) setImages(data);
+  }, [data]);
+
+  const fetchMutation = useMutation({
+    mutationFn: () =>
+      apiFetch(`/stories/${storyId}/fetch-images`, { method: "POST" }),
+    onSuccess: () => refetch(),
+  });
+
+  const patchMutation = useMutation({
+    mutationFn: ({ id, patch }: { id: string; patch: Partial<Asset> }) =>
+      apiFetch(`/stories/${storyId}/images/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      }),
+  });
+
+  function toggleSelected(index: number) {
+    const img = images[index];
+    const updated = [...images];
+    updated[index] = { ...img, selected: !img.selected };
+    setImages(updated);
+    patchMutation.mutate({ id: img.id, patch: { selected: !img.selected } });
+  }
+
+  function handleDragStart(
+    e: React.DragEvent<HTMLDivElement>,
+    index: number,
+  ) {
+    e.dataTransfer.setData("text/plain", index.toString());
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>, index: number) {
+    e.preventDefault();
+    const from = Number(e.dataTransfer.getData("text/plain"));
+    if (isNaN(from)) return;
+    const updated = [...images];
+    const [moved] = updated.splice(from, 1);
+    updated.splice(index, 0, moved);
+    setImages(updated);
+    updated.forEach((img, i) => {
+      patchMutation.mutate({ id: img.id, patch: { rank: i } });
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <button
+        className="border px-3 py-1 rounded"
+        onClick={() => fetchMutation.mutate()}
+        disabled={fetchMutation.isLoading}
+      >
+        Auto-fetch images
+      </button>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        {images.map((img, index) => (
+          <div
+            key={img.id}
+            className={`relative border ${img.selected ? "ring-2 ring-blue-500" : ""}`}
+            draggable
+            onDragStart={(e) => handleDragStart(e, index)}
+            onDragOver={handleDragOver}
+            onDrop={(e) => handleDrop(e, index)}
+            onClick={() => toggleSelected(index)}
+          >
+            <Image
+              src={img.remote_url}
+              alt=""
+              width={160}
+              height={160}
+              className="w-full h-40 object-cover"
+            />
+            {img.selected && (
+              <span className="absolute top-1 left-1 bg-blue-500 text-white text-xs px-1 rounded">
+                Selected
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/apps/web/src/app/stories/[id]/page.tsx
+++ b/apps/web/src/app/stories/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
 import { marked } from "marked";
+import ImagesTab from "./images-tab";
 
 interface Story {
   id: string;
@@ -23,6 +24,7 @@ export default function StoryEditorPage({
   const [form, setForm] = useState<Story | null>(null);
   const [toast, setToast] = useState<Toast | null>(null);
   const isInitial = useRef(true);
+  const [tab, setTab] = useState<"content" | "images">("content");
 
   function showToast(toast: Toast) {
     setToast(toast);
@@ -85,36 +87,59 @@ export default function StoryEditorPage({
           {toast.message}
         </div>
       )}
-      <input
-        type="text"
-        className="border p-2 w-full rounded"
-        value={form.title}
-        onChange={(e) => setForm({ ...form, title: e.target.value })}
-      />
-      <div>
-        <label className="mr-2">Status:</label>
-        <select
-          className="border rounded p-1"
-          value={form.status}
-          onChange={(e) =>
-            setForm({ ...form, status: e.target.value as Story["status"] })
-          }
+      <div className="flex gap-4 border-b pb-2">
+        <button
+          className={`px-3 py-1 ${
+            tab === "content" ? "border-b-2 border-white" : "text-gray-500"
+          }`}
+          onClick={() => setTab("content")}
         >
-          <option value="draft">Draft</option>
-          <option value="approved">Approved</option>
-        </select>
+          Content
+        </button>
+        <button
+          className={`px-3 py-1 ${
+            tab === "images" ? "border-b-2 border-white" : "text-gray-500"
+          }`}
+          onClick={() => setTab("images")}
+        >
+          Images
+        </button>
       </div>
-      <div className="flex gap-4">
-        <textarea
-          className="w-1/2 border p-2 rounded h-96"
-          value={form.body_md}
-          onChange={(e) => setForm({ ...form, body_md: e.target.value })}
-        />
-        <div
-          className="w-1/2 border p-2 rounded h-96 overflow-auto"
-          dangerouslySetInnerHTML={{ __html: preview }}
-        />
-      </div>
+      {tab === "content" && (
+        <>
+          <input
+            type="text"
+            className="border p-2 w-full rounded"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+          />
+          <div>
+            <label className="mr-2">Status:</label>
+            <select
+              className="border rounded p-1"
+              value={form.status}
+              onChange={(e) =>
+                setForm({ ...form, status: e.target.value as Story["status"] })
+              }
+            >
+              <option value="draft">Draft</option>
+              <option value="approved">Approved</option>
+            </select>
+          </div>
+          <div className="flex gap-4">
+            <textarea
+              className="w-1/2 border p-2 rounded h-96"
+              value={form.body_md}
+              onChange={(e) => setForm({ ...form, body_md: e.target.value })}
+            />
+            <div
+              className="w-1/2 border p-2 rounded h-96 overflow-auto"
+              dangerouslySetInnerHTML={{ __html: preview }}
+            />
+          </div>
+        </>
+      )}
+      {tab === "images" && <ImagesTab storyId={id} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add tabbed navigation to story editor with new Images tab
- implement image fetching, selection, and drag-and-drop ordering

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68966b63e000833289185851ff2c42e1