### PR TITLE
docs: add docker compose setup and env samples

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,17 @@
+# Root environment variables for local development
+# Copy to .env and adjust values as needed.
+
+# Database configuration
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=dark_life
+POSTGRES_PORT=5432
+
+# Redis connection
+REDIS_URL=redis://redis:6379/0
+
+# Provider API keys (required for image search and narration)
+PEXELS_API_KEY=your_pexels_api_key
+PIXABAY_API_KEY=your_pixabay_api_key
+OPENAI_API_KEY=your_openai_api_key
+ELEVENLABS_API_KEY=your_elevenlabs_api_key

--- a/README.md
+++ b/README.md
@@ -2,29 +2,68 @@
 
 Monorepo for automating short-form dark storytelling videos.
 
-## Services
+## Running with Docker Compose
 
-- **webapp/** – Flask UI for fetching and preparing stories. Generates render jobs in `render_queue/`.
-- **video_renderer/** – Polls render jobs and builds final videos and manifests.
-- **video_uploader/** – Cron-style uploader that reads manifests and posts videos to social platforms.
-- **shared/** – Common utilities and configuration.
+1. **Copy environment files**
+   - `cp .env.sample .env`
+   - `cp apps/api/.env.sample apps/api/.env`
+   - `cp apps/web/.env.sample apps/web/.env`
+   - Fill in API keys and secrets as described below.
+
+2. **Start the stack**
+
+```bash
+cd infra
+docker compose up --build
+```
+
+This brings up Postgres, Redis, the FastAPI backend on port `8000` and the Next.js web app on port `3000`.
+
+Visit [`http://localhost:3000`](http://localhost:3000) for the web UI and [`http://localhost:8000/health`](http://localhost:8000/health) for a basic API health check.
+
+## Environment variables
+
+### Root `.env`
+
+| Key | Description |
+| --- | ----------- |
+| `POSTGRES_USER` | Postgres user created for the development database |
+| `POSTGRES_PASSWORD` | Password for the Postgres user |
+| `POSTGRES_DB` | Name of the development database |
+| `POSTGRES_PORT` | Local port exposed for Postgres |
+| `REDIS_URL` | Connection string for Redis |
+| `PEXELS_API_KEY` | API key used for image search |
+| `PIXABAY_API_KEY` | API key used for image search fallback |
+| `OPENAI_API_KEY` | API key used by renderer services for narration |
+| `ELEVENLABS_API_KEY` | API key for voice synthesis |
+
+### `apps/api/.env`
+
+| Key | Description |
+| --- | ----------- |
+| `DATABASE_URL` | SQLAlchemy connection URL for Postgres |
+| `REDIS_URL` | Connection string for Redis |
+| `PEXELS_API_KEY` | API key used for image search |
+| `PIXABAY_API_KEY` | API key used for image search fallback |
+| `OPENAI_API_KEY` | API key used for AI features |
+| `ELEVENLABS_API_KEY` | API key for voice synthesis |
+
+### `apps/web/.env`
+
+| Key | Description |
+| --- | ----------- |
+| `NEXT_PUBLIC_API_BASE_URL` | Base URL the web app uses to reach the API |
+
+## Renderer and Uploader Integration
+
+Existing renderer and uploader services live in the `video_renderer/` and `video_uploader/` directories. The FastAPI backend creates render jobs that these services can consume. Ensure they share access to the same `.env` values and directories (`render_queue/` and `output/`) when running them alongside the stack.
 
 ## Development
 
-This project uses [uv](https://github.com/astral-sh/uv) for dependency management.
+This project uses [uv](https://github.com/astral-sh/uv) for Python dependency management and Next.js for the web frontend. Standard `make` targets are available for running tests and individual services:
 
 ```bash
-make init
+make init    # set up the Python virtual environment
+make test    # run the test suite
 ```
 
-Run individual services:
-
-```bash
-make run-webapp      # start the Flask app
-make run-renderer    # process queued render jobs
-make run-uploader    # upload finished videos
-```
-
-## Configuration
-
-Copy `sample.env` to `.env` and fill in required API keys for services like Reddit and Instagram.

--- a/apps/api/.env.sample
+++ b/apps/api/.env.sample
@@ -1,0 +1,12 @@
+# Environment variables for Dark Life API
+# Copy to apps/api/.env and adjust values.
+
+# Connection URLs
+DATABASE_URL=postgresql+psycopg://postgres:postgres@postgres:5432/dark_life
+REDIS_URL=redis://redis:6379/0
+
+# Provider API keys
+PEXELS_API_KEY=your_pexels_api_key
+PIXABAY_API_KEY=your_pixabay_api_key
+OPENAI_API_KEY=your_openai_api_key
+ELEVENLABS_API_KEY=your_elevenlabs_api_key

--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,0 +1,5 @@
+# Environment variables for Dark Life Web (Next.js)
+# Copy to apps/web/.env and adjust values.
+
+# Base URL for the API
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.sample
 
 # vercel
 .vercel

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,52 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-dark_life}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+  api:
+    image: tiangolo/uvicorn-gunicorn-fastapi:python3.11
+    volumes:
+      - ..:/app
+    env_file:
+      - ../apps/api/.env
+    environment:
+      MODULE_NAME: apps.api.main
+      VARIABLE_NAME: app
+      PORT: 8000
+    depends_on:
+      - postgres
+      - redis
+    ports:
+      - "8000:8000"
+
+  web:
+    image: node:20
+    working_dir: /app/apps/web
+    volumes:
+      - ..:/app
+    command: sh -c "npm install && npm run dev"
+    env_file:
+      - ../apps/web/.env
+    depends_on:
+      - api
+    ports:
+      - "3000:3000"
+
+volumes:
+  pgdata:

--- a/sample.env
+++ b/sample.env
@@ -1,7 +1,0 @@
-# Copy to .env and replace placeholders with your own credentials
-REDDIT_CLIENT_ID=your_reddit_client_id
-REDDIT_CLIENT_SECRET=your_reddit_client_secret
-REDDIT_USER_AGENT=dark-life-script/0.1 by your_username
-PEXELS_API_KEY=your_pexels_api_key
-ELEVENLABS_API_KEY=your_elevenlabs_api_key
-OPENAI_API_KEY=your_openai_api_key


### PR DESCRIPTION
## Summary
- document docker compose workflow in README
- add env.sample files for root, API, and web apps
- introduce docker-compose.yml with Postgres, Redis, API, and web services

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689672f7bdb4833294937ecf8a87952e