### PR TITLE
Add renderer job poller and tests

### DIFF
--- a/services/renderer/poller.py
+++ b/services/renderer/poller.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Simple poller that processes queued render jobs from the jobs table."""
+
+import sqlite3
+import time
+from pathlib import Path
+
+import typer
+
+from shared.config import settings
+
+app = typer.Typer(add_completion=False)
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    status TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+def _db_path() -> Path:
+    """Return path to the jobs database."""
+    return settings.BASE_DIR / "jobs.db"
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(SCHEMA)
+    conn.commit()
+
+
+def process_once(conn: sqlite3.Connection) -> bool:
+    """Process a single queued render job.
+
+    Returns True if a job was processed.
+    """
+    cur = conn.execute(
+        "SELECT id, payload FROM jobs WHERE status = 'queued' AND kind = 'render' ORDER BY created_at LIMIT 1"
+    )
+    row = cur.fetchone()
+    if row is None:
+        return False
+
+    job_id, payload = row
+    # Mark running
+    conn.execute("UPDATE jobs SET status = 'running', updated_at = CURRENT_TIMESTAMP WHERE id = ?", (job_id,))
+    conn.commit()
+
+    # Print payload for demonstration
+    print(payload)
+
+    # Mark success
+    conn.execute("UPDATE jobs SET status = 'success', updated_at = CURRENT_TIMESTAMP WHERE id = ?", (job_id,))
+    conn.commit()
+    return True
+
+
+@app.command()
+def run(interval: float = 1.0) -> None:
+    """Continuously poll for queued render jobs."""
+    db_path = _db_path()
+    conn = sqlite3.connect(db_path)
+    try:
+        _ensure_schema(conn)
+        while True:
+            processed = process_once(conn)
+            if not processed:
+                time.sleep(interval)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tests/test_renderer_poller.py
+++ b/tests/test_renderer_poller.py
@@ -1,0 +1,37 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from shared.config import settings
+from services.renderer import poller
+
+
+def test_poller_processes_job(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(settings, "BASE_DIR", tmp_path)
+    db_path = tmp_path / "jobs.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE jobs (id INTEGER PRIMARY KEY AUTOINCREMENT, kind TEXT, status TEXT, payload TEXT, created_at TEXT, updated_at TEXT)"
+    )
+    payload = json.dumps({"story": 123})
+    conn.execute("INSERT INTO jobs (kind, status, payload) VALUES ('render', 'queued', ?)", (payload,))
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        processed = poller.process_once(conn)
+    finally:
+        conn.close()
+
+    assert processed
+    out = capsys.readouterr().out.strip()
+    assert out == payload
+
+    conn = sqlite3.connect(db_path)
+    status = conn.execute("SELECT status FROM jobs WHERE id = 1").fetchone()[0]
+    conn.close()
+    assert status == "success"


### PR DESCRIPTION
## Summary
- add renderer poller that scans jobs table for queued render jobs and marks them successful after printing their payload
- add test covering poller behavior

## Testing
- `PYTHONPATH=. pytest tests/test_renderer_poller.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896760eae508332b50732e7572908f8