### PR TITLE
feat: add story CRUD API

### DIFF
--- a/apps/api/db.py
+++ b/apps/api/db.py
@@ -1,0 +1,25 @@
+"""Database configuration for the API."""
+
+from __future__ import annotations
+
+from sqlmodel import SQLModel, Session, create_engine
+
+from shared.config import settings
+
+
+engine = create_engine(settings.DATABASE_URL, echo=False)
+
+
+def init_db() -> None:
+    """Create database tables."""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    """Yield a database session."""
+    with Session(engine) as session:
+        yield session
+
+
+__all__ = ["engine", "init_db", "get_session"]
+

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,28 @@
+"""FastAPI application setup."""
+
+from __future__ import annotations
+
+import logging
+
 from fastapi import FastAPI
 
+from .db import init_db
+from .stories import router as stories_router
+
+
+logger = logging.getLogger(__name__)
+
 app = FastAPI(title="Dark Life API")
+app.include_router(stories_router)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialize application services."""
+    try:
+        init_db()
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("Database initialization failed: %s", exc)
 
 
 @app.get("/health")

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -1,0 +1,64 @@
+"""Database models for the API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, func
+from sqlmodel import Field, SQLModel
+
+
+class StoryBase(SQLModel):
+    """Shared fields for Story models."""
+
+    title: str
+    subreddit: Optional[str] = None
+    source_url: Optional[str] = None
+    body_md: Optional[str] = None
+    status: str = "draft"
+
+
+class Story(StoryBase, table=True):
+    """Story table model."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime | None = Field(
+        sa_column=Column(DateTime(timezone=True), server_default=func.now())
+    )
+    updated_at: datetime | None = Field(
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        )
+    )
+
+
+class StoryCreate(StoryBase):
+    """Payload for creating stories."""
+
+
+class StoryRead(StoryBase):
+    """Story representation returned by the API."""
+
+    id: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class StoryUpdate(SQLModel):
+    """Payload for updating stories."""
+
+    title: Optional[str] = None
+    subreddit: Optional[str] = None
+    source_url: Optional[str] = None
+    body_md: Optional[str] = None
+    status: Optional[str] = None
+
+
+__all__ = [
+    "Story",
+    "StoryCreate",
+    "StoryRead",
+    "StoryUpdate",
+]
+

--- a/apps/api/stories.py
+++ b/apps/api/stories.py
@@ -1,0 +1,74 @@
+"""Stories API router."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from .db import get_session
+from .models import Story, StoryCreate, StoryRead, StoryUpdate
+
+
+router = APIRouter(prefix="/stories", tags=["stories"])
+
+
+@router.get("/", response_model=list[StoryRead])
+def list_stories(session: Session = Depends(get_session)) -> list[StoryRead]:
+    """Return all stories."""
+    return session.exec(select(Story)).all()
+
+
+@router.get("/{story_id}", response_model=StoryRead)
+def get_story(story_id: int, session: Session = Depends(get_session)) -> StoryRead:
+    """Return a story by ID."""
+    story = session.get(Story, story_id)
+    if not story:
+        raise HTTPException(status_code=404, detail="Story not found")
+    return story
+
+
+@router.post("/", response_model=StoryRead, status_code=status.HTTP_201_CREATED)
+def create_story(
+    story_in: StoryCreate, session: Session = Depends(get_session)
+) -> StoryRead:
+    """Create a new story."""
+    story = Story(**story_in.model_dump())
+    session.add(story)
+    session.commit()
+    session.refresh(story)
+    return story
+
+
+@router.patch("/{story_id}", response_model=StoryRead)
+def update_story(
+    story_id: int, story_in: StoryUpdate, session: Session = Depends(get_session)
+) -> StoryRead:
+    """Update an existing story."""
+    story = session.get(Story, story_id)
+    if not story:
+        raise HTTPException(status_code=404, detail="Story not found")
+    data = story_in.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(story, key, value)
+    story.updated_at = datetime.utcnow()
+    session.add(story)
+    session.commit()
+    session.refresh(story)
+    return story
+
+
+@router.delete("/{story_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_story(story_id: int, session: Session = Depends(get_session)) -> None:
+    """Delete a story."""
+    story = session.get(Story, story_id)
+    if not story:
+        raise HTTPException(status_code=404, detail="Story not found")
+    session.delete(story)
+    session.commit()
+    return None
+
+
+__all__ = ["router"]
+

--- a/apps/web/src/app/stories/[id]/page.tsx
+++ b/apps/web/src/app/stories/[id]/page.tsx
@@ -7,7 +7,7 @@ import { marked } from "marked";
 import ImagesTab from "./images-tab";
 
 interface Story {
-  id: string;
+  id: number;
   title: string;
   body_md: string;
   status: "draft" | "approved";

--- a/apps/web/src/app/stories/page.tsx
+++ b/apps/web/src/app/stories/page.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { apiFetch } from "@/lib/api";
 
 interface Story {
-  id: string;
+  id: number;
   title: string;
 }
 
@@ -42,7 +42,7 @@ export default function StoriesPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) => apiFetch(`/stories/${id}`, { method: "DELETE" }),
+    mutationFn: (id: number) => apiFetch(`/stories/${id}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["stories"] });
       showToast({ type: "success", message: "Story deleted" });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "fastapi",
+    "sqlmodel",
+    "psycopg2-binary",
 ]
 
 [project.scripts]

--- a/shared/config.py
+++ b/shared/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from dotenv import load_dotenv
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 load_dotenv()
@@ -22,6 +23,10 @@ class Settings(BaseSettings):
     VIDEO_OUTPUT_DIR: Path = OUTPUT_DIR / "videos"
     MANIFEST_DIR: Path = OUTPUT_DIR / "manifest"
     RENDER_QUEUE_DIR: Path = BASE_DIR / "render_queue"
+    DATABASE_URL: str = Field(
+        default="postgresql://postgres:postgres@localhost:5432/darklife",
+        description="Postgres connection string",
+    )
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- add SQLModel `Story` model with timestamps
- implement FastAPI router for story CRUD and integrate into app
- align Next.js story pages with API and use numeric IDs

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ffmpeg')*
- `cd apps/web && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68967fb961448332b6b618e47afd4eda