### PR TITLE
feat: transcribe narration audio with faster-whisper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "fastapi",
     "sqlmodel",
     "psycopg2-binary",
+    "faster-whisper",
 ]
 
 [project.scripts]

--- a/tests/test_create_slideshow.py
+++ b/tests/test_create_slideshow.py
@@ -27,7 +27,9 @@ def expected_filters(subtitle_path: Path | None, dark_overlay: bool, zoom: bool)
         base_filters.append("[vx1]drawbox=t=fill:color=black@0.4[v_dark]")
         last = "[v_dark]"
     if subtitle_path:
-        base_filters.append(f"{last}subtitles={subtitle_path.as_posix()}[v_final]")
+        base_filters.append(
+            f"{last}subtitles='{subtitle_path.as_posix()}'[v_final]"
+        )
         last = "[v_final]"
     return base_filters, last
 

--- a/video_renderer/create_slideshow.py
+++ b/video_renderer/create_slideshow.py
@@ -67,7 +67,8 @@ def build_video_filters(
         last = "[v_dark]"
 
     if subtitle:
-        filters.append(f"{last}subtitles={subtitle.as_posix()}[v_final]")
+        # Quote the subtitle path to allow for spaces in directories
+        filters.append(f"{last}subtitles='{subtitle.as_posix()}'[v_final]")
         last = "[v_final]"
 
     return filters, last

--- a/video_renderer/render_job_runner.py
+++ b/video_renderer/render_job_runner.py
@@ -41,7 +41,7 @@ def _process_job(job: RenderJob) -> bool:
     try:
         whisper_subs.main(
             input_dir=settings.CONTENT_DIR / "audio" / "voiceovers",
-            stories_dir=settings.STORIES_DIR,
+            output_dir=settings.CONTENT_DIR / "subtitles",
         )
     except Exception:
         logger.exception("Subtitle creation failed for %s", story_id)
@@ -49,7 +49,14 @@ def _process_job(job: RenderJob) -> bool:
 
     # Create video slideshow
     try:
-        create_slideshow.main(["--story_id", story_id])
+        create_slideshow.main(
+            [
+                "--story_id",
+                story_id,
+                "--subtitles-dir",
+                str(settings.CONTENT_DIR / "subtitles"),
+            ]
+        )
     except Exception:
         logger.exception("Slideshow rendering failed for %s", story_id)
         return False


### PR DESCRIPTION
## Summary
- add faster-whisper transcription to generate SRT subtitles for narration mp3s
- quote subtitle paths when burning them into videos
- call subtitle generation and pass SRT directory during render job processing
- remove unsupported sample MP3 test fixture

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'video_renderer', 'dotenv', 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6896e431c32883329d9ebfc388290036