### PR TITLE
refactor: handle optional deps and improve subtitle util

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from dotenv import load_dotenv
+try:  # Optional dependency
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - dotenv not installed
+    def load_dotenv(*args, **kwargs):  # type: ignore
+        return None
 from pydantic import Field
 from pydantic_settings import BaseSettings
 

--- a/shared/reddit.py
+++ b/shared/reddit.py
@@ -7,7 +7,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-from dotenv import load_dotenv
+try:  # Optional dependency
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - dotenv not installed
+    def load_dotenv(*args, **kwargs):  # type: ignore
+        return None
+
 import requests
 import typer
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is importable when running tests with importlib mode
+sys.path.append(str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- make config and reddit modules tolerant of missing python-dotenv
- remove heavy CLI deps from whisper_subs and streamline SRT writing
- add conftest to ensure tests locate project packages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896ef91845c8332ba5634566753a2be