### PR TITLE
Add unit tests for Reddit ingestor

### DIFF
--- a/services/reddit_ingestor/tests/conftest.py
+++ b/services/reddit_ingestor/tests/conftest.py
@@ -1,0 +1,91 @@
+import types
+import sys
+from importlib import reload
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def ingestor_env(tmp_path, monkeypatch):
+    """Prepare isolated env and database for tests."""
+    # Ensure repository root is on sys.path for imports
+    repo_root = Path(__file__).resolve().parents[3]
+    sys.path.append(str(repo_root))
+
+    db_url = f"sqlite:///{tmp_path}/reddit.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("METRICS_ENABLED", "false")
+    monkeypatch.setenv("MIN_BODY_CHARS", "1")
+    monkeypatch.setenv("MAX_BODY_CHARS", "1000")
+    monkeypatch.setenv("LANG_ALLOW", "en")
+    monkeypatch.setenv("ALLOW_NSFW", "false")
+
+    from importlib import import_module
+
+    monitoring = import_module("services.reddit_ingestor.monitoring")
+    storage = import_module("services.reddit_ingestor.storage")
+    backfill = import_module("services.reddit_ingestor.backfill")
+    incremental = import_module("services.reddit_ingestor.incremental")
+    normalizer = import_module("services.reddit_ingestor.normalizer")
+
+    # Reload modules that depend on DATABASE_URL or other env vars
+    reload(storage)
+    reload(backfill)
+    reload(incremental)
+    reload(normalizer)
+
+    # Create minimal schema
+    with storage.engine.begin() as conn:
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE IF NOT EXISTS reddit_posts (
+                id TEXT PRIMARY KEY,
+                reddit_id TEXT UNIQUE,
+                subreddit TEXT NOT NULL,
+                title TEXT NOT NULL,
+                author TEXT,
+                url TEXT NOT NULL,
+                created_utc TIMESTAMP NOT NULL,
+                is_self BOOLEAN NOT NULL,
+                selftext TEXT,
+                nsfw BOOLEAN NOT NULL,
+                language TEXT,
+                upvotes INTEGER NOT NULL,
+                num_comments INTEGER NOT NULL,
+                hash_title_body TEXT NOT NULL,
+                UNIQUE(subreddit, hash_title_body)
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE IF NOT EXISTS reddit_rejections (
+                id TEXT PRIMARY KEY,
+                reddit_id TEXT NOT NULL,
+                subreddit TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                payload TEXT,
+                created_at TIMESTAMP
+            )
+            """
+        )
+        conn.exec_driver_sql(
+            """
+            CREATE TABLE IF NOT EXISTS reddit_fetch_state (
+                id TEXT PRIMARY KEY,
+                subreddit TEXT UNIQUE NOT NULL,
+                last_fullname TEXT,
+                last_created_utc TIMESTAMP,
+                backfill_earliest_utc TIMESTAMP,
+                mode TEXT NOT NULL,
+                updated_at TIMESTAMP
+            )
+            """
+        )
+    return types.SimpleNamespace(
+        storage=storage,
+        backfill=backfill,
+        incremental=incremental,
+        normalizer=normalizer,
+    )

--- a/services/reddit_ingestor/tests/test_ingestor.py
+++ b/services/reddit_ingestor/tests/test_ingestor.py
@@ -1,0 +1,135 @@
+from datetime import datetime, timezone
+from sqlalchemy import text
+
+
+def test_normalization_filters(ingestor_env, monkeypatch):
+    normalizer = ingestor_env.normalizer
+    config = normalizer.NormalizationConfig(
+        lang_allow="en", allow_nsfw=False, min_body_chars=5, max_body_chars=1000
+    )
+
+    # NSFW rejection
+    post = {"title": "t", "selftext": "hello" * 2, "over_18": True}
+    normalized, reason = normalizer.normalize_post(post, config)
+    assert normalized is None and reason == "nsfw"
+
+    # Too short rejection
+    post = {"title": "t", "selftext": "hi"}
+    normalized, reason = normalizer.normalize_post(post, config)
+    assert normalized is None and reason == "too_short"
+
+    # Language mismatch
+    monkeypatch.setattr(normalizer, "detect", lambda text: "fr")
+    post = {"title": "bonjour", "selftext": "bonjour " * 3}
+    normalized, reason = normalizer.normalize_post(post, config)
+    assert normalized is None and reason == "lang_fr"
+
+    # Normalization of boilerplate and whitespace
+    monkeypatch.setattr(normalizer, "detect", lambda text: "en")
+    post = {"title": "A", "selftext": "Edit: ignore\nLine1\n\nLine2"}
+    normalized, reason = normalizer.normalize_post(post, config)
+    assert normalized.body == "Line1 Line2" and reason is None
+
+
+def test_insert_post_deduplication(ingestor_env):
+    storage = ingestor_env.storage
+    session = storage.SessionLocal()
+    payload = {
+        "reddit_id": "t3_1",
+        "subreddit": "testsub",
+        "title": "Title 1",
+        "author": "user",
+        "url": "http://example.com/1",
+        "created_utc": datetime.now(timezone.utc),
+        "is_self": True,
+        "selftext": "body1",
+        "nsfw": False,
+        "language": "en",
+        "upvotes": 1,
+        "num_comments": 0,
+        "hash_title_body": "hash1",
+    }
+    assert storage.insert_post(session, payload) is True
+    assert storage.insert_post(session, payload) is False
+
+    payload2 = dict(payload, reddit_id="t3_2")
+    assert storage.insert_post(session, payload2) is False
+
+    payload3 = dict(payload, reddit_id="t3_3", hash_title_body="hash3")
+    assert storage.insert_post(session, payload3) is True
+    session.close()
+
+
+def test_backfill_flow(ingestor_env, monkeypatch):
+    storage = ingestor_env.storage
+    backfill = ingestor_env.backfill
+    normalizer = ingestor_env.normalizer
+    monkeypatch.setattr(normalizer, "detect", lambda text: "en")
+
+    class FakeClient:
+        def fetch_posts_by_time_window(self, subreddit, start_utc, end_utc, limit=100):
+            posts = [
+                {
+                    "id": "1",
+                    "name": "t3_1",
+                    "title": "Post1",
+                    "selftext": "body one " * 5,
+                    "url": "http://x/1",
+                    "author": "a",
+                    "created_utc": start_utc + 10,
+                    "over_18": False,
+                },
+                {
+                    "id": "2",
+                    "name": "t3_2",
+                    "title": "Post2",
+                    "selftext": "body two " * 5,
+                    "url": "http://x/2",
+                    "author": "b",
+                    "created_utc": start_utc + 20,
+                    "over_18": False,
+                },
+            ]
+            return posts, None
+
+    inserted, earliest = backfill.backfill_by_window("testsub", 0, 100, client=FakeClient())
+    assert inserted == 2 and earliest is not None
+
+    with storage.engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM reddit_posts")).scalar()
+    assert count == 2
+
+
+def test_incremental_idempotency(ingestor_env, monkeypatch):
+    incremental = ingestor_env.incremental
+    normalizer = ingestor_env.normalizer
+    monkeypatch.setattr(normalizer, "detect", lambda text: "en")
+
+    class FakeClient:
+        def fetch_new_posts(self, subreddit, after=None, limit=100):
+            posts = [
+                {
+                    "id": "new",
+                    "name": "t3_new",
+                    "title": "New",
+                    "selftext": "body new " * 5,
+                    "url": "http://x/new",
+                    "author": "a",
+                    "created_utc": 200,
+                },
+                {
+                    "id": "old",
+                    "name": "t3_old",
+                    "title": "Old",
+                    "selftext": "body old " * 5,
+                    "url": "http://x/old",
+                    "author": "b",
+                    "created_utc": 100,
+                },
+            ]
+            return posts, None
+
+    client = FakeClient()
+    first = incremental.fetch_incremental("testsub", client=client)
+    second = incremental.fetch_incremental("testsub", client=client)
+    assert first == 2 and second == 0


### PR DESCRIPTION
## Summary
- add test fixtures that configure env vars and SQLite schema for Reddit ingestor
- cover normalization, deduplication, backfill and incremental flows
- verify idempotency by rerunning incremental batch with no new inserts

## Testing
- `pytest services/reddit_ingestor/tests/test_ingestor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689730920b7883329714a23b0fa6a1b2