### PR TITLE
feat: fuzzy dedup and image URL extraction for reddit ingestor

### DIFF
--- a/services/reddit_ingestor/events.py
+++ b/services/reddit_ingestor/events.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Light-weight event publisher for newly ingested stories.
+
+Posts that are successfully stored are forwarded to a web API so that other
+components of the system can react to new content in near real time. The target
+endpoint is configured via the ``LIVE_UPDATE_URL`` environment variable. When
+unset, publishing is skipped.
+"""
+
+import logging
+import os
+from typing import Any, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+LIVE_UPDATE_URL = os.getenv("LIVE_UPDATE_URL")
+
+
+def push_new_story(payload: Dict[str, Any]) -> None:
+    """Send ``payload`` to the configured live update API.
+
+    Any network errors are logged and swallowed to avoid interfering with the
+    ingestion pipeline.
+    """
+
+    if not LIVE_UPDATE_URL:
+        return
+    try:
+        requests.post(LIVE_UPDATE_URL, json=payload, timeout=5)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        logger.warning("push_new_story_failed", extra={"error": str(exc)})
+
+
+__all__ = ["push_new_story"]

--- a/services/reddit_ingestor/media.py
+++ b/services/reddit_ingestor/media.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Helpers for extracting media information from Reddit posts."""
+
+from html import unescape
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+
+
+def _add_url(urls: List[str], url: str | None) -> None:
+    if not url:
+        return
+    parsed = urlparse(url)
+    if parsed.netloc.endswith("redd.it"):
+        clean = unescape(url)
+        if clean not in urls:
+            urls.append(clean)
+
+
+def extract_image_urls(post: Dict[str, Any]) -> List[str]:
+    """Return list of Reddit-hosted image URLs from ``post``."""
+
+    urls: List[str] = []
+    preview = post.get("preview", {})
+    for image in preview.get("images", []):
+        _add_url(urls, image.get("source", {}).get("url"))
+        for res in image.get("resolutions", []):
+            _add_url(urls, res.get("url"))
+
+    media_metadata = post.get("media_metadata", {})
+    for item in media_metadata.values():
+        _add_url(urls, item.get("s", {}).get("u"))
+        for res in item.get("p", []):
+            _add_url(urls, res.get("u"))
+
+    _add_url(urls, post.get("url"))
+    return urls
+
+
+__all__ = ["extract_image_urls"]

--- a/services/reddit_ingestor/migrations/0002_add_image_urls.py
+++ b/services/reddit_ingestor/migrations/0002_add_image_urls.py
@@ -1,0 +1,22 @@
+"""Add image_urls column to reddit_posts
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2025-08-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("reddit_posts", sa.Column("image_urls", sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("reddit_posts", "image_urls")

--- a/services/reddit_ingestor/tests/conftest.py
+++ b/services/reddit_ingestor/tests/conftest.py
@@ -23,6 +23,7 @@ def ingestor_env(tmp_path, monkeypatch):
 
     from importlib import import_module
 
+    config_module = import_module("shared.config")
     monitoring = import_module("services.reddit_ingestor.monitoring")
     storage = import_module("services.reddit_ingestor.storage")
     backfill = import_module("services.reddit_ingestor.backfill")
@@ -30,6 +31,7 @@ def ingestor_env(tmp_path, monkeypatch):
     normalizer = import_module("services.reddit_ingestor.normalizer")
 
     # Reload modules that depend on DATABASE_URL or other env vars
+    reload(config_module)
     reload(storage)
     reload(backfill)
     reload(incremental)
@@ -54,6 +56,7 @@ def ingestor_env(tmp_path, monkeypatch):
                 upvotes INTEGER NOT NULL,
                 num_comments INTEGER NOT NULL,
                 hash_title_body TEXT NOT NULL,
+                image_urls TEXT,
                 UNIQUE(subreddit, hash_title_body)
             )
             """


### PR DESCRIPTION
## Summary
- deduplicate similar posts across subreddits using fuzzy text matching
- extract reddit-hosted image URLs and persist them with posts
- push newly ingested stories to configured live-update API

## Testing
- `pytest services/reddit_ingestor/tests/test_ingestor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6897371c348083328e27727d685928bd