### PR TITLE
Use regex keyword list for story image search

### DIFF
--- a/apps/api/stories.py
+++ b/apps/api/stories.py
@@ -27,11 +27,29 @@ from .models import (
 router = APIRouter(prefix="/stories", tags=["stories"])
 
 
+# Domain-specific keywords for image search
+KEYWORDS = [
+    "cabin",
+    "forest",
+    "fog",
+    "attic",
+    "window",
+    "shadow",
+    "alley",
+    "night",
+    "mist",
+    "abandoned",
+]
+KEYWORD_RE = re.compile(r"\b(" + "|".join(re.escape(k) for k in KEYWORDS) + r")\b", re.IGNORECASE)
+
+
 def _extract_keywords(story: Story) -> str:
-    """Return a simple space-separated keyword string from a story."""
-    text = f"{story.title} {story.body_md or ''}"
-    words = re.findall(r"[a-zA-Z]+", text.lower())
-    return " ".join(words[:5])
+    """Return matched domain keywords from a story title/body."""
+    text = f"{story.title} {story.body_md or ''}".lower()
+    matches = KEYWORD_RE.findall(text)
+    # remove duplicates while preserving order
+    keywords = list(dict.fromkeys(matches))
+    return " ".join(keywords)
 
 
 def _fetch_pexels(keywords: str) -> Iterable[dict[str, str]]:

--- a/tests/test_stories_api.py
+++ b/tests/test_stories_api.py
@@ -5,6 +5,8 @@ import pytest
 
 from apps.api.main import app
 from apps.api.db import get_session
+from apps.api.stories import _extract_keywords
+from apps.api.models import Story
 
 
 @pytest.fixture(name="client")
@@ -80,3 +82,12 @@ def test_split_story_parts_order(client: TestClient):
     second_part_text = parts[1]["body_md"]
     assert "sentence 0" in first_part_text
     assert "sentence 4" in second_part_text
+
+
+def test_extract_keywords_matches_domain_list():
+    story = Story(
+        title="Lonely Cabin",
+        body_md="A forest shadow hides in the attic at night.",
+    )
+    keywords = _extract_keywords(story)
+    assert keywords.split() == ["cabin", "forest", "shadow", "attic", "night"]


### PR DESCRIPTION
## Summary
- extract image-search keywords using a fixed regex list (cabin, forest, etc.)
- test that story titles/bodies match the predefined keywords

## Testing
- `pytest tests/test_stories_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689773b340e8833281c80377be4abe6b