### PR TITLE
Add tests for stories API and service stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ smoke:
 	uv run python scripts/smoke_e2e.py
 
 test:
-	uv run --with pytest pytest -q
+	uv run --with pytest,httpx pytest -q

--- a/tests/api/test_stories_endpoints.py
+++ b/tests/api/test_stories_endpoints.py
@@ -1,0 +1,124 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from apps.api.main import app
+from apps.api.db import get_session
+import apps.api.stories as stories
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def get_test_session():
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def test_create_and_update_story(client: TestClient):
+    res = client.post("/stories", json={"title": "My Story"})
+    assert res.status_code == 201
+    story = res.json()
+
+    res = client.patch(
+        f"/stories/{story['id']}",
+        json={"body_md": "Hello world", "status": "approved"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["body_md"] == "Hello world"
+    assert data["status"] == "approved"
+
+
+def test_fetch_images_creates_assets(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    story = client.post(
+        "/stories",
+        json={"title": "Forest Story", "body_md": "a forest at night"},
+    ).json()
+
+    monkeypatch.setattr(
+        stories,
+        "_fetch_pexels",
+        lambda keywords: [
+            {"remote_url": "http://img/1.jpg", "provider": "pexels", "provider_id": "1"}
+        ],
+    )
+    monkeypatch.setattr(
+        stories,
+        "_fetch_pixabay",
+        lambda keywords: [
+            {"remote_url": "http://img/2.jpg", "provider": "pixabay", "provider_id": "2"}
+        ],
+    )
+
+    res = client.post(f"/stories/{story['id']}/fetch-images")
+    assert res.status_code == 200
+    assets = res.json()
+    assert len(assets) == 2
+    urls = {a["remote_url"] for a in assets}
+    assert urls == {"http://img/1.jpg", "http://img/2.jpg"}
+
+
+def test_split_endpoint_creates_parts(client: TestClient):
+    body = " ".join([f"Sentence {i}." for i in range(20)])
+    story = client.post(
+        "/stories", json={"title": "Split", "body_md": body}
+    ).json()
+
+    res = client.post(f"/stories/{story['id']}/split", params={"target_seconds": 5})
+    assert res.status_code == 200
+    parts = res.json()
+    assert len(parts) >= 2
+    assert [p["index"] for p in parts] == list(range(1, len(parts) + 1))
+
+
+def test_enqueue_series_creates_jobs(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    body = "Sentence one. Sentence two. Sentence three."
+    story = client.post(
+        "/stories", json={"title": "Full", "body_md": body}
+    ).json()
+
+    monkeypatch.setattr(
+        stories,
+        "_fetch_pexels",
+        lambda keywords: [
+            {"remote_url": "http://img/1.jpg", "provider": "pexels", "provider_id": "1"}
+        ],
+    )
+    monkeypatch.setattr(stories, "_fetch_pixabay", lambda keywords: [])
+
+    res = client.post(f"/stories/{story['id']}/fetch-images")
+    assert res.status_code == 200
+    asset_id = res.json()[0]["id"]
+
+    res = client.patch(
+        f"/stories/{story['id']}/images/{asset_id}", json={"selected": True}
+    )
+    assert res.status_code == 200
+
+    parts = client.post(
+        f"/stories/{story['id']}/split", params={"target_seconds": 10}
+    ).json()
+
+    res = client.post(f"/stories/{story['id']}/enqueue-series")
+    assert res.status_code == 202
+    data = res.json()
+    assert len(data["jobs"]) == len(parts)
+
+    jobs_res = client.get("/jobs", params={"story_id": story["id"]})
+    assert jobs_res.status_code == 200
+    jobs = jobs_res.json()
+    assert len(jobs) == len(parts)
+    assert all(job["status"] == "queued" for job in jobs)

--- a/tests/services/test_renderer_stub.py
+++ b/tests/services/test_renderer_stub.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from shared.config import settings
+from shared.types import RenderJob
+from video_renderer import render_job_runner
+
+
+def test_process_job_writes_manifest(tmp_path, monkeypatch):
+    content_dir = tmp_path / "content"
+    stories_dir = content_dir / "stories"
+    stories_dir.mkdir(parents=True)
+    video_dir = tmp_path / "videos"
+    manifest_dir = tmp_path / "manifest"
+
+    monkeypatch.setattr(settings, "CONTENT_DIR", content_dir)
+    monkeypatch.setattr(settings, "STORIES_DIR", stories_dir)
+    monkeypatch.setattr(settings, "VIDEO_OUTPUT_DIR", video_dir)
+    monkeypatch.setattr(settings, "MANIFEST_DIR", manifest_dir)
+
+    story_file = stories_dir / "1.md"
+    story_file.write_text("story")
+
+    job = RenderJob(story_path=story_file, image_paths=[])
+
+    def fake_voiceover(input_dir: Path, output_dir: Path) -> None:
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    def fake_whisper(input_dir: Path, output_dir: Path) -> None:
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    def fake_slideshow(args: list[str]) -> int:
+        story_id = args[args.index("--story_id") + 1]
+        video_dir.mkdir(parents=True, exist_ok=True)
+        (video_dir / f"{story_id}_final.mp4").write_text("video")
+        return 0
+
+    monkeypatch.setattr(render_job_runner.voiceover, "main", fake_voiceover)
+    monkeypatch.setattr(render_job_runner.whisper_subs, "main", fake_whisper)
+    monkeypatch.setattr(render_job_runner.create_slideshow, "main", fake_slideshow)
+
+    assert render_job_runner._process_job(job)
+    manifest_file = manifest_dir / "1.json"
+    assert manifest_file.exists()

--- a/tests/services/test_uploader_stub.py
+++ b/tests/services/test_uploader_stub.py
@@ -1,0 +1,41 @@
+import pytest
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from apps.api.models import Story, Job
+from shared.config import settings
+from video_uploader import cron_upload
+
+
+def test_cron_upload_dry_run(tmp_path, monkeypatch, capsys):
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        story = Story(title="Test Story", status="approved")
+        session.add(story)
+        session.commit()
+        session.refresh(story)
+        story_id = story.id
+        job = Job(
+            story_id=story_id,
+            kind="render_part",
+            status="success",
+            payload={"story_id": story_id, "part_index": 1},
+        )
+        session.add(job)
+        session.commit()
+
+    video_dir = tmp_path / "videos"
+    video_dir.mkdir()
+    (video_dir / f"{story_id}_p01.mp4").write_text("video")
+    monkeypatch.setattr(settings, "VIDEO_OUTPUT_DIR", video_dir)
+
+    monkeypatch.setattr(cron_upload, "create_engine", lambda url, echo=False: engine)
+
+    cron_upload.run(limit=1, dry_run=True)
+    captured = capsys.readouterr()
+    assert "DRY RUN" in captured.out


### PR DESCRIPTION
## Summary
- add unit tests for story creation, updates, image fetch, split, and job enqueue API endpoints
- add integration tests for renderer and uploader stubs using temporary directories
- ensure `make test` installs httpx and runs all tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689775570a60833298a4c012739439d8