### PR TITLE
Share output volume between renderer and uploader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ No optional features — just the minimal happy path.
 ## PHASE 0 — Verify Bring-up
 - [ ] `docker compose up --build` runs Postgres, Redis, FastAPI (:8000), Next.js (:3000).
 - [ ] `.env` has DB, Redis, image API key, YouTube creds.
-- [ ] Renderer & uploader share the same `/output` volume.
+- [x] Renderer & uploader share the same `/output` volume.
 
 ---
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -48,5 +48,26 @@ services:
     ports:
       - "3000:3000"
 
+  renderer:
+    image: python:3.11
+    working_dir: /app
+    volumes:
+      - ..:/app
+      - output:/output
+    command: sh -c "sleep infinity"
+    profiles:
+      - workers
+
+  uploader:
+    image: python:3.11
+    working_dir: /app
+    volumes:
+      - ..:/app
+      - output:/output
+    command: sh -c "sleep infinity"
+    profiles:
+      - workers
+
 volumes:
   pgdata:
+  output:


### PR DESCRIPTION
## Summary
- Add renderer and uploader services to docker-compose with a shared `output` volume
- Mark volume-sharing task as complete in AGENTS checklist

## Testing
- `docker-compose -f infra/docker-compose.yml config`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68977d2333048332bb12aa671387a56f