### PR TITLE
feat(api): support updating story image assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ No optional features — just the minimal happy path.
 ## PHASE 1 — Image Fetch & Selection (UI ↔ API)
 - [ ] Implement `POST /api/stories/{id}/fetch-images` → hits Pexels/Pixabay → stores candidates in `assets` table (selected=false, rank=null).
 - [ ] Implement `GET /api/stories/{id}/images` → returns candidates.
-- [ ] Implement `PATCH /api/stories/{id}/images/{assetId}` → toggle selected/rank.
+- [x] Implement `PATCH /api/stories/{id}/images/{assetId}` → toggle selected/rank.
 - [ ] Web UI “Images” tab:
     - Fetch images button.
     - Grid of thumbnails, selectable.

--- a/apps/api/stories.py
+++ b/apps/api/stories.py
@@ -219,9 +219,9 @@ def update_image(
     asset_in: AssetUpdate,
     session: Session = Depends(get_session),
 ) -> AssetRead:
-    """Update selection or rank for an image asset."""
+    """Update fields like ``selected`` or ``rank`` for an image asset."""
     asset = session.get(Asset, asset_id)
-    if not asset or asset.story_id != story_id:
+    if not asset or asset.story_id != story_id or asset.type != "image":
         raise HTTPException(status_code=404, detail="Image not found")
     data = asset_in.model_dump(exclude_unset=True)
     for key, value in data.items():


### PR DESCRIPTION
## Summary
- allow updating a story's image asset fields like `selected` and `rank`
- check off Phase 1 task for image patch endpoint in AGENTS checklist

## Testing
- `pytest tests/test_stories_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68978306378c8332bfe15a2a92235c6f