### PR TITLE
feat: add image fetching endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ No optional features — just the minimal happy path.
 ---
 
 ## PHASE 1 — Image Fetch & Selection (UI ↔ API)
-- [ ] Implement `POST /api/stories/{id}/fetch-images` → hits Pexels/Pixabay → stores candidates in `assets` table (selected=false, rank=null).
+- [x] Implement `POST /api/stories/{id}/fetch-images` → hits Pexels/Pixabay → stores candidates in `assets` table (selected=false, rank=null).
 - [ ] Implement `GET /api/stories/{id}/images` → returns candidates.
 - [ ] Implement `PATCH /api/stories/{id}/images/{assetId}` → toggle selected/rank.
 - [ ] Web UI “Images” tab:

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -92,7 +92,7 @@ class Asset(SQLModel, table=True):
     provider: Optional[str] = None
     provider_id: Optional[str] = None
     selected: bool = False
-    rank: int = 0
+    rank: Optional[int] = None
     created_at: datetime | None = Field(
         sa_column=Column(DateTime(timezone=True), server_default=func.now())
     )
@@ -109,7 +109,7 @@ class AssetRead(SQLModel):
     id: int
     remote_url: str
     selected: bool = False
-    rank: int = 0
+    rank: Optional[int] = None
 
 
 class AssetUpdate(SQLModel):

--- a/apps/api/stories.py
+++ b/apps/api/stories.py
@@ -180,16 +180,19 @@ def fetch_images(story_id: int, session: Session = Depends(get_session)) -> list
             select(Asset).where(Asset.story_id == story_id, Asset.type == "image")
         ).all()
     }
-    for idx, data in enumerate(assets_data):
-        if not data.get("remote_url") or data["remote_url"] in existing_urls:
+    for data in assets_data:
+        url = data.get("remote_url")
+        if not url or url in existing_urls:
             continue
+        existing_urls.add(url)
         asset = Asset(
             story_id=story_id,
             type="image",
-            remote_url=data["remote_url"],
+            remote_url=url,
             provider=data.get("provider"),
             provider_id=data.get("provider_id"),
-            rank=idx,
+            selected=False,
+            rank=None,
         )
         session.add(asset)
         assets.append(asset)

--- a/tests/api/test_stories_endpoints.py
+++ b/tests/api/test_stories_endpoints.py
@@ -69,6 +69,7 @@ def test_fetch_images_creates_assets(client: TestClient, monkeypatch: pytest.Mon
     assert len(assets) == 2
     urls = {a["remote_url"] for a in assets}
     assert urls == {"http://img/1.jpg", "http://img/2.jpg"}
+    assert all(a["selected"] is False and a["rank"] is None for a in assets)
 
 
 def test_split_endpoint_creates_parts(client: TestClient):


### PR DESCRIPTION
## Summary
- add `/api/stories/{id}/fetch-images` to pull images from Pexels and Pixabay
- allow `Asset.rank` to be nullable and default to not selected
- test story image fetching behavior and defaults

## Testing
- `pytest tests/api/test_stories_endpoints.py -q`
- `pytest tests/test_stories_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689783022a9c8332bce48c913182f07a