### PR TITLE
Add endpoint to list story images in rank order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,9 @@ No optional features — just the minimal happy path.
 ---
 
 ## PHASE 1 — Image Fetch & Selection (UI ↔ API)
-- [ ] Implement `POST /api/stories/{id}/fetch-images` → hits Pexels/Pixabay → stores candidates in `assets` table (selected=false, rank=null).
- - [x] Implement `GET /api/stories/{id}/images` → returns candidates.
-- [ ] Implement `PATCH /api/stories/{id}/images/{assetId}` → toggle selected/rank.
+- [x] Implement `POST /api/stories/{id}/fetch-images` → hits Pexels/Pixabay → stores candidates in `assets` table (selected=false, rank=null).
+- [x] Implement `GET /api/stories/{id}/images` → returns candidates.
+- [x] Implement `PATCH /api/stories/{id}/images/{assetId}` → toggle selected/rank.
 - [ ] Web UI “Images” tab:
     - Fetch images button.
     - Grid of thumbnails, selectable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ No optional features — just the minimal happy path.
 
 ## PHASE 1 — Image Fetch & Selection (UI ↔ API)
 - [ ] Implement `POST /api/stories/{id}/fetch-images` → hits Pexels/Pixabay → stores candidates in `assets` table (selected=false, rank=null).
-- [ ] Implement `GET /api/stories/{id}/images` → returns candidates.
+ - [x] Implement `GET /api/stories/{id}/images` → returns candidates.
 - [ ] Implement `PATCH /api/stories/{id}/images/{assetId}` → toggle selected/rank.
 - [ ] Web UI “Images” tab:
     - Fetch images button.

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -92,7 +92,7 @@ class Asset(SQLModel, table=True):
     provider: Optional[str] = None
     provider_id: Optional[str] = None
     selected: bool = False
-    rank: int = 0
+    rank: Optional[int] = None
     created_at: datetime | None = Field(
         sa_column=Column(DateTime(timezone=True), server_default=func.now())
     )
@@ -109,7 +109,7 @@ class AssetRead(SQLModel):
     id: int
     remote_url: str
     selected: bool = False
-    rank: int = 0
+    rank: Optional[int] = None
 
 
 class AssetUpdate(SQLModel):

--- a/apps/api/stories.py
+++ b/apps/api/stories.py
@@ -201,14 +201,14 @@ def fetch_images(story_id: int, session: Session = Depends(get_session)) -> list
 
 @router.get("/{story_id}/images", response_model=list[AssetRead])
 def list_images(story_id: int, session: Session = Depends(get_session)) -> list[AssetRead]:
-    """List images associated with a story."""
+    """Return image assets for a story ordered by rank."""
     story = session.get(Story, story_id)
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
     return session.exec(
         select(Asset)
         .where(Asset.story_id == story_id, Asset.type == "image")
-        .order_by(Asset.rank)
+        .order_by(Asset.rank.is_(None), Asset.rank, Asset.id)
     ).all()
 
 

--- a/tests/api/test_stories_endpoints.py
+++ b/tests/api/test_stories_endpoints.py
@@ -71,6 +71,64 @@ def test_fetch_images_creates_assets(client: TestClient, monkeypatch: pytest.Mon
     assert urls == {"http://img/1.jpg", "http://img/2.jpg"}
 
 
+def test_get_images_returns_rank_order(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    story = client.post("/stories", json={"title": "Ranked"}).json()
+
+    monkeypatch.setattr(
+        stories,
+        "_fetch_pexels",
+        lambda keywords: [
+            {"remote_url": "http://img/1.jpg", "provider": "pexels", "provider_id": "1"},
+            {"remote_url": "http://img/2.jpg", "provider": "pexels", "provider_id": "2"},
+        ],
+    )
+    monkeypatch.setattr(stories, "_fetch_pixabay", lambda keywords: [])
+
+    res = client.post(f"/stories/{story['id']}/fetch-images")
+    assert res.status_code == 200
+    assets = res.json()
+
+    # swap ranks
+    res = client.patch(
+        f"/stories/{story['id']}/images/{assets[0]['id']}", json={"rank": 1}
+    )
+    assert res.status_code == 200
+    res = client.patch(
+        f"/stories/{story['id']}/images/{assets[1]['id']}", json={"rank": 0}
+    )
+    assert res.status_code == 200
+
+    res = client.get(f"/stories/{story['id']}/images")
+    assert res.status_code == 200
+    ids = [a["id"] for a in res.json()]
+    assert ids == [assets[1]["id"], assets[0]["id"]]
+
+
+def test_get_images_unranked_last(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    story = client.post("/stories", json={"title": "Ranked"}).json()
+
+    monkeypatch.setattr(
+        stories,
+        "_fetch_pexels",
+        lambda keywords: [
+            {"remote_url": "http://img/1.jpg", "provider": "pexels", "provider_id": "1"},
+            {"remote_url": "http://img/2.jpg", "provider": "pexels", "provider_id": "2"},
+            {"remote_url": "http://img/3.jpg", "provider": "pexels", "provider_id": "3"},
+        ],
+    )
+    monkeypatch.setattr(stories, "_fetch_pixabay", lambda keywords: [])
+
+    assets = client.post(f"/stories/{story['id']}/fetch-images").json()
+
+    client.patch(f"/stories/{story['id']}/images/{assets[0]['id']}", json={"rank": 0})
+    client.patch(f"/stories/{story['id']}/images/{assets[1]['id']}", json={"rank": 1})
+
+    res = client.get(f"/stories/{story['id']}/images")
+    assert res.status_code == 200
+    ids = [a["id"] for a in res.json()]
+    assert ids == [assets[0]["id"], assets[1]["id"], assets[2]["id"]]
+
+
 def test_split_endpoint_creates_parts(client: TestClient):
     body = " ".join([f"Sentence {i}." for i in range(20)])
     story = client.post(

--- a/tests/api/test_stories_endpoints.py
+++ b/tests/api/test_stories_endpoints.py
@@ -69,39 +69,8 @@ def test_fetch_images_creates_assets(client: TestClient, monkeypatch: pytest.Mon
     assert len(assets) == 2
     urls = {a["remote_url"] for a in assets}
     assert urls == {"http://img/1.jpg", "http://img/2.jpg"}
+    assert all(a["selected"] is False and a["rank"] is None for a in assets)
 
-
-def test_get_images_returns_rank_order(client: TestClient, monkeypatch: pytest.MonkeyPatch):
-    story = client.post("/stories", json={"title": "Ranked"}).json()
-
-    monkeypatch.setattr(
-        stories,
-        "_fetch_pexels",
-        lambda keywords: [
-            {"remote_url": "http://img/1.jpg", "provider": "pexels", "provider_id": "1"},
-            {"remote_url": "http://img/2.jpg", "provider": "pexels", "provider_id": "2"},
-        ],
-    )
-    monkeypatch.setattr(stories, "_fetch_pixabay", lambda keywords: [])
-
-    res = client.post(f"/stories/{story['id']}/fetch-images")
-    assert res.status_code == 200
-    assets = res.json()
-
-    # swap ranks
-    res = client.patch(
-        f"/stories/{story['id']}/images/{assets[0]['id']}", json={"rank": 1}
-    )
-    assert res.status_code == 200
-    res = client.patch(
-        f"/stories/{story['id']}/images/{assets[1]['id']}", json={"rank": 0}
-    )
-    assert res.status_code == 200
-
-    res = client.get(f"/stories/{story['id']}/images")
-    assert res.status_code == 200
-    ids = [a["id"] for a in res.json()]
-    assert ids == [assets[1]["id"], assets[0]["id"]]
 
 
 def test_get_images_unranked_last(client: TestClient, monkeypatch: pytest.MonkeyPatch):
@@ -180,3 +149,43 @@ def test_enqueue_series_creates_jobs(client: TestClient, monkeypatch: pytest.Mon
     jobs = jobs_res.json()
     assert len(jobs) == len(parts)
     assert all(job["status"] == "queued" for job in jobs)
+
+
+def test_list_images_returns_in_rank_order(client: TestClient, monkeypatch: pytest.MonkeyPatch):
+    """Test that GET /stories/{id}/images returns images in rank order."""
+    story = client.post(
+        "/stories", json={"title": "Test Story", "body_md": "forest cabin night"}
+    ).json()
+
+    # Mock image fetch to return multiple images
+    monkeypatch.setattr(
+        stories,
+        "_fetch_pexels",
+        lambda keywords: [
+            {"remote_url": "http://img/1.jpg", "provider": "pexels", "provider_id": "1"},
+            {"remote_url": "http://img/2.jpg", "provider": "pexels", "provider_id": "2"},
+            {"remote_url": "http://img/3.jpg", "provider": "pexels", "provider_id": "3"},
+        ],
+    )
+    monkeypatch.setattr(stories, "_fetch_pixabay", lambda keywords: [])
+
+    # Fetch images
+    res = client.post(f"/stories/{story['id']}/fetch-images")
+    assert res.status_code == 200
+    assets = res.json()
+    assert len(assets) == 3
+
+    # Set ranks in non-sequential order to test sorting
+    client.patch(f"/stories/{story['id']}/images/{assets[0]['id']}", json={"rank": 3})
+    client.patch(f"/stories/{story['id']}/images/{assets[1]['id']}", json={"rank": 1})
+    client.patch(f"/stories/{story['id']}/images/{assets[2]['id']}", json={"rank": 2})
+
+    # Get images and verify they are returned in rank order
+    images_res = client.get(f"/stories/{story['id']}/images")
+    assert images_res.status_code == 200
+    images = images_res.json()
+    assert len(images) == 3
+    
+    # Verify order by rank (and then by id for consistent ordering)
+    ranks = [img["rank"] for img in images if img["rank"] is not None]
+    assert ranks == [1, 2, 3]

--- a/tests/api/test_stories_endpoints.py
+++ b/tests/api/test_stories_endpoints.py
@@ -71,8 +71,6 @@ def test_fetch_images_creates_assets(client: TestClient, monkeypatch: pytest.Mon
     assert urls == {"http://img/1.jpg", "http://img/2.jpg"}
     assert all(a["selected"] is False and a["rank"] is None for a in assets)
 
-
-
 def test_get_images_unranked_last(client: TestClient, monkeypatch: pytest.MonkeyPatch):
     story = client.post("/stories", json={"title": "Ranked"}).json()
 
@@ -96,6 +94,7 @@ def test_get_images_unranked_last(client: TestClient, monkeypatch: pytest.Monkey
     assert res.status_code == 200
     ids = [a["id"] for a in res.json()]
     assert ids == [assets[0]["id"], assets[1]["id"], assets[2]["id"]]
+
 
 
 def test_split_endpoint_creates_parts(client: TestClient):


### PR DESCRIPTION
## Summary
- add handler to return story image assets ordered by rank
- ensure unranked images appear after ranked ones
- test image listing order including unranked assets

## Testing
- `pytest tests/api/test_stories_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68978303ef7883328738af0179bb45d0