### PR TITLE
feat(web): reorder images with drag-and-drop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ No optional features — just the minimal happy path.
 - [x] Implement `POST /api/stories/{id}/fetch-images` → hits Pexels/Pixabay → stores candidates in `assets` table (selected=false, rank=null).
 - [x] Implement `GET /api/stories/{id}/images` → returns candidates.
 - [x] Implement `PATCH /api/stories/{id}/images/{assetId}` → toggle selected/rank.
- - [x] Web UI "Images" tab:
+- [x] Web UI "Images" tab:
     - Fetch images button.
     - Grid of thumbnails, selectable.
     - Drag-sort to set rank.

--- a/apps/web/src/app/stories/[id]/images-tab.tsx
+++ b/apps/web/src/app/stories/[id]/images-tab.tsx
@@ -82,9 +82,12 @@ export default function ImagesTab({ storyId }: { storyId: string }) {
     const updated = [...images];
     const [moved] = updated.splice(from, 1);
     updated.splice(index, 0, moved);
-    setImages(updated);
-    updated.forEach((img, i) => {
-      patchMutation.mutate({ id: img.id, patch: { rank: i } });
+    const withRank = updated.map((img, i) => ({ ...img, rank: i }));
+    setImages(withRank);
+    withRank.forEach((img, i) => {
+      if (images[i]?.id !== img.id) {
+        patchMutation.mutate({ id: img.id, patch: { rank: i } });
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- support drag-and-drop reordering in the Images tab
- persist new ordering by PATCHing image ranks
- mark Web UI Images tab task as complete in AGENTS.md

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68986a0aeb04833281a8be47634d0b6d