### PR TITLE
Add cron uploader script and crontab example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ No optional features — just the minimal happy path.
     - Find earliest rendered, unuploaded part.
     - Upload to YouTube Shorts (vertical ≤ 60s).
     - Record in `uploads` table.
-- [ ] Scheduler script `cron_upload.py`:
+- [x] Scheduler script `cron_upload.py`:
     - Run uploader once per execution.
     - Add to README: daily cron example.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Existing renderer and uploader services live in the `video_renderer/` and `video
 3. Run `make uploader` once. If `YOUTUBE_TOKEN_FILE` does not exist, a browser window opens to complete the OAuth flow and the token is saved to that path.
 4. Subsequent `make uploader` runs will upload the next rendered part using the stored token.
 
+To automate uploads daily at 9 AM, add a crontab entry like:
+
+```bash
+0 9 * * * cd /path/to/dark-life && python cron_upload.py
+```
+
 ## Development
 
 This project uses [uv](https://github.com/astral-sh/uv) for Python dependency management and Next.js for the web frontend. Standard `make` targets are available for running tests and individual services:

--- a/cron_upload.py
+++ b/cron_upload.py
@@ -1,0 +1,12 @@
+"""Run the uploader once. Useful for cron jobs."""
+
+from services.uploader.upload_youtube import run as upload_once
+
+
+def main() -> None:
+    """Upload the next rendered part to YouTube."""
+    upload_once(dry_run=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add cron_upload.py to run YouTube uploader once
- document daily cron usage in README
- mark Phase 4 uploader scheduler task complete

## Testing
- `uv run --with pytest,httpx pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689896b0d62c8332b7c59514661142cc