### PR TITLE
feat: add reddit ingestion admin tools

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,6 +23,10 @@ REDDIT_CLIENT_ID=your_reddit_client_id
 REDDIT_CLIENT_SECRET=your_reddit_client_secret
 # Optional: customize the User-Agent string for Reddit requests
 REDDIT_USER_AGENT=dark-life-script
+REDDIT_DEFAULT_SUBREDDITS=nosleep,confession
+REDDIT_MIN_UPVOTES=200
+ADMIN_API_TOKEN=changeme
+NEXT_PUBLIC_ADMIN_TOKEN=changeme
 
 # YouTube uploader credentials
 # Path to OAuth client secrets JSON and token file for YouTube API

--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,10 @@ smoke:
 	python scripts/smoke_e2e.py
 
 test:
-	uv run --with pytest,httpx pytest -q
+        uv run --with pytest,httpx pytest -q
+
+reddit-backfill:
+        uv run python -m services.reddit_ingestor.cli backfill --subreddits "$(SUBS)" --earliest $(EARLIEST)
+
+reddit-incremental:
+        uv run python -m services.reddit_ingestor.cli incremental --subreddits "$(SUBS)"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Use `make down` to stop the Docker services when finished.
 | `YOUTUBE_CLIENT_SECRETS_FILE` | Path to OAuth client secrets JSON for YouTube uploads |
 | `YOUTUBE_TOKEN_FILE` | Path to stored OAuth token for YouTube |
 | `NEXT_PUBLIC_API_BASE_URL` | Base URL the web app uses to reach the API |
+| `REDDIT_CLIENT_ID` | Reddit API client id |
+| `REDDIT_CLIENT_SECRET` | Reddit API client secret |
+| `REDDIT_USER_AGENT` | User agent string for Reddit requests |
+| `REDDIT_DEFAULT_SUBREDDITS` | Default subreddits for ingestion |
+| `REDDIT_MIN_UPVOTES` | Minimum score required to accept a post |
+| `ADMIN_API_TOKEN` | Token required for admin Reddit endpoints |
+| `NEXT_PUBLIC_ADMIN_TOKEN` | Same token exposed to the web UI |
 
 ### `apps/api/.env`
 
@@ -94,6 +101,38 @@ Use `make down` to stop the Docker services when finished.
 | Key | Description |
 | --- | ----------- |
 | `NEXT_PUBLIC_API_BASE_URL` | Base URL the web app uses to reach the API |
+
+## Reddit Ingestion
+
+The project can pull stories from Reddit either via the CLI or the web admin.
+
+### CLI
+
+```
+make reddit-backfill SUBS="nosleep,confession" EARLIEST="2008-01-01"
+make reddit-incremental SUBS="nosleep,confession"
+```
+
+### Admin UI
+
+Visit `http://localhost:3000/admin/reddit` to trigger ingestion jobs, view
+fetch state, inspect recent jobs and promote posts to stories. Requests require
+the token set in `ADMIN_API_TOKEN` via the `X-Admin-Token` header. The web UI
+reads this from `NEXT_PUBLIC_ADMIN_TOKEN`.
+
+### Worker
+
+Queued jobs are processed by running:
+
+```
+uv run python -m services.reddit_ingestor.worker run
+```
+
+### Troubleshooting
+
+* Ensure Reddit credentials and tokens are set in the environment.
+* Reddit API rate limits may throttle requests; retry later if jobs fail.
+* If jobs remain queued verify the worker process is running.
 
 ## Renderer and Uploader Integration
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from .db import init_db
 from .stories import router as stories_router
 from .jobs import router as jobs_router
+from .reddit_admin import router as reddit_admin_router
 
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="Dark Life API")
 app.include_router(stories_router)
 app.include_router(jobs_router)
+app.include_router(reddit_admin_router)
 
 
 @app.on_event("startup")

--- a/apps/api/reddit_admin.py
+++ b/apps/api/reddit_admin.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from sqlmodel import Session, select
+from sqlalchemy import Table, Column, DateTime, Text, MetaData, func
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+from .db import get_session
+from .models import Job, Story
+from services.reddit_ingestor.storage import reddit_posts
+
+router = APIRouter(prefix="/admin/reddit", tags=["admin-reddit"])
+
+ADMIN_TOKEN = os.getenv("ADMIN_API_TOKEN")
+
+def require_token(x_admin_token: str = Header(..., alias="X-Admin-Token")) -> None:
+    if not ADMIN_TOKEN or x_admin_token != ADMIN_TOKEN:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
+def _default_subreddits() -> List[str]:
+    env = os.getenv("REDDIT_DEFAULT_SUBREDDITS", "")
+    return [s.strip() for s in env.split(",") if s.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Table definition for reddit_fetch_state
+# ---------------------------------------------------------------------------
+metadata = MetaData()
+reddit_fetch_state = Table(
+    "reddit_fetch_state",
+    metadata,
+    Column("id", PG_UUID(as_uuid=True), primary_key=True),
+    Column("subreddit", Text, unique=True, nullable=False),
+    Column("last_fullname", Text),
+    Column("last_created_utc", DateTime(timezone=True)),
+    Column("backfill_earliest_utc", DateTime(timezone=True)),
+    Column("updated_at", DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
+)
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+from pydantic import BaseModel
+
+class BackfillRequest(BaseModel):
+    subreddits: Optional[List[str]] = None
+    earliest: Optional[str] = None
+
+class IncrementalRequest(BaseModel):
+    subreddits: Optional[List[str]] = None
+
+class PromoteRequest(BaseModel):
+    reddit_ids: List[str]
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/backfill")
+def enqueue_backfill(
+    req: BackfillRequest,
+    session: Session = Depends(get_session),
+    _: None = Depends(require_token),
+) -> dict:
+    subs = req.subreddits or _default_subreddits()
+    jobs: List[dict] = []
+    for sub in subs:
+        job = Job(kind="reddit_backfill", status="queued", payload={"subreddit": sub, "earliest": req.earliest})
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        jobs.append({"id": job.id, "subreddit": sub, "kind": job.kind, "status": job.status})
+    return {"jobs": jobs}
+
+
+@router.post("/incremental")
+def enqueue_incremental(
+    req: IncrementalRequest,
+    session: Session = Depends(get_session),
+    _: None = Depends(require_token),
+) -> dict:
+    subs = req.subreddits or _default_subreddits()
+    jobs: List[dict] = []
+    for sub in subs:
+        job = Job(kind="reddit_incremental", status="queued", payload={"subreddit": sub})
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        jobs.append({"id": job.id, "subreddit": sub, "kind": job.kind, "status": job.status})
+    return {"jobs": jobs}
+
+
+@router.get("/state")
+def fetch_state(
+    subreddit: Optional[str] = None,
+    session: Session = Depends(get_session),
+    _: None = Depends(require_token),
+):
+    stmt = select(
+        reddit_fetch_state.c.subreddit,
+        reddit_fetch_state.c.last_fullname,
+        reddit_fetch_state.c.last_created_utc,
+        reddit_fetch_state.c.backfill_earliest_utc,
+        reddit_fetch_state.c.updated_at,
+    )
+    if subreddit:
+        stmt = stmt.where(reddit_fetch_state.c.subreddit == subreddit)
+    rows = session.exec(stmt).all()
+    return [dict(r._mapping) for r in rows]
+
+
+@router.get("/jobs", response_model=list[Job])
+def list_reddit_jobs(
+    status: Optional[str] = None,
+    kind: Optional[str] = None,
+    session: Session = Depends(get_session),
+    _: None = Depends(require_token),
+) -> list[Job]:
+    stmt = select(Job).where(Job.kind.ilike("reddit_%"))
+    if status:
+        stmt = stmt.where(Job.status == status)
+    if kind:
+        stmt = stmt.where(Job.kind == kind)
+    stmt = stmt.order_by(Job.id.desc()).limit(100)
+    return session.exec(stmt).all()
+
+
+@router.get("/posts")
+def list_posts(
+    subreddit: Optional[str] = None,
+    q: Optional[str] = None,
+    since: Optional[datetime] = None,
+    session: Session = Depends(get_session),
+    _: None = Depends(require_token),
+):
+    stmt = select(reddit_posts)
+    if subreddit:
+        stmt = stmt.where(reddit_posts.c.subreddit == subreddit)
+    if q:
+        stmt = stmt.where(reddit_posts.c.title.ilike(f"%{q}%"))
+    if since:
+        stmt = stmt.where(reddit_posts.c.created_utc >= since)
+    stmt = stmt.order_by(reddit_posts.c.created_utc.desc()).limit(100)
+    rows = session.exec(stmt).all()
+    return [dict(r._mapping) for r in rows]
+
+
+@router.post("/promote")
+def promote_posts(
+    req: PromoteRequest,
+    session: Session = Depends(get_session),
+    _: None = Depends(require_token),
+) -> dict:
+    created: List[int] = []
+    for rid in req.reddit_ids:
+        row = session.exec(
+            select(reddit_posts).where(reddit_posts.c.reddit_id == rid)
+        ).first()
+        if row:
+            payload = row._mapping
+            story = Story(
+                title=payload.get("title"),
+                subreddit=payload.get("subreddit"),
+                source_url=payload.get("url"),
+                body_md=payload.get("selftext"),
+                status="draft",
+            )
+            session.add(story)
+            session.commit()
+            session.refresh(story)
+            created.append(story.id)
+    return {"created_story_ids": created}
+
+
+__all__ = ["router"]

--- a/apps/web/src/app/admin/reddit/page.tsx
+++ b/apps/web/src/app/admin/reddit/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+const ADMIN_TOKEN = process.env.NEXT_PUBLIC_ADMIN_TOKEN || "";
+
+interface Job {
+  id: number;
+  subreddit: string;
+  kind: string;
+  status: string;
+}
+
+interface StateRow {
+  subreddit: string;
+  last_fullname?: string | null;
+  last_created_utc?: string | null;
+  backfill_earliest_utc?: string | null;
+  updated_at?: string | null;
+}
+
+interface PostRow {
+  reddit_id: string;
+  title: string;
+  subreddit: string;
+  created_utc: string;
+}
+
+export default function RedditAdminPage() {
+  const [subs, setSubs] = useState("nosleep,confession");
+  const [earliest, setEarliest] = useState("2008-01-01");
+  const [state, setState] = useState<StateRow[]>([]);
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [posts, setPosts] = useState<PostRow[]>([]);
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+
+  const headers = { "X-Admin-Token": ADMIN_TOKEN };
+
+  async function refresh() {
+    const s = await fetch(`${API_BASE}/api/admin/reddit/state`, { headers }).then((r) => r.json());
+    setState(s);
+    const j = await fetch(`${API_BASE}/api/admin/reddit/jobs`, { headers }).then((r) => r.json());
+    setJobs(j);
+    const p = await fetch(`${API_BASE}/api/admin/reddit/posts`, { headers }).then((r) => r.json());
+    setPosts(p);
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function runIncremental() {
+    await fetch(`${API_BASE}/api/admin/reddit/incremental`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ subreddits: subs.split(",").map((s) => s.trim()).filter(Boolean) }),
+    });
+    refresh();
+  }
+
+  async function runBackfill() {
+    await fetch(`${API_BASE}/api/admin/reddit/backfill`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ subreddits: subs.split(",").map((s) => s.trim()).filter(Boolean), earliest }),
+    });
+    refresh();
+  }
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => ({ ...prev, [id]: !prev[id] }));
+  }
+
+  async function promoteSelected() {
+    const ids = Object.keys(selected).filter((k) => selected[k]);
+    if (!ids.length) return;
+    await fetch(`${API_BASE}/api/admin/reddit/promote`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ reddit_ids: ids }),
+    });
+    refresh();
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Reddit Admin</h1>
+      <div className="space-x-2">
+        <input
+          className="border p-1"
+          value={subs}
+          onChange={(e) => setSubs(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-2" onClick={runIncremental}>Run Incremental</button>
+        <input
+          className="border p-1"
+          value={earliest}
+          onChange={(e) => setEarliest(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-2" onClick={runBackfill}>Run Backfill</button>
+        <button className="bg-green-600 text-white px-2" onClick={promoteSelected}>Promote Selected</button>
+        <button className="px-2" onClick={refresh}>Refresh</button>
+      </div>
+
+      <h2 className="font-semibold">State</h2>
+      <table className="border">
+        <thead>
+          <tr><th>Subreddit</th><th>Last Fullname</th><th>Last Created</th><th>Backfill Earliest</th></tr>
+        </thead>
+        <tbody>
+          {state.map((row) => (
+            <tr key={row.subreddit}>
+              <td>{row.subreddit}</td>
+              <td>{row.last_fullname}</td>
+              <td>{row.last_created_utc}</td>
+              <td>{row.backfill_earliest_utc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 className="font-semibold">Jobs</h2>
+      <table className="border">
+        <thead>
+          <tr><th>ID</th><th>Subreddit</th><th>Kind</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => (
+            <tr key={job.id}>
+              <td>{job.id}</td>
+              <td>{(job.payload as any)?.subreddit ?? job.subreddit}</td>
+              <td>{job.kind}</td>
+              <td>{job.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 className="font-semibold">Posts</h2>
+      <table className="border">
+        <thead>
+          <tr><th></th><th>Reddit ID</th><th>Subreddit</th><th>Title</th><th>Created</th></tr>
+        </thead>
+        <tbody>
+          {posts.map((p) => (
+            <tr key={p.reddit_id}>
+              <td>
+                <input type="checkbox" checked={!!selected[p.reddit_id]} onChange={() => toggleSelect(p.reddit_id)} />
+              </td>
+              <td>{p.reddit_id}</td>
+              <td>{p.subreddit}</td>
+              <td>{p.title}</td>
+              <td>{p.created_utc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/services/reddit_ingestor/backfill.py
+++ b/services/reddit_ingestor/backfill.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 import logging
 import time
 import uuid
+import os
 from typing import List, Optional, Tuple
 
 from sqlalchemy import Column, DateTime, MetaData, Table, Text, func
@@ -41,6 +42,7 @@ from .storage import (
 )
 
 logger = logging.getLogger(__name__)
+MIN_UPVOTES = int(os.getenv("REDDIT_MIN_UPVOTES", "0"))
 
 # ---------------------------------------------------------------------------
 # ``reddit_fetch_state`` table (minimal definition for updates)
@@ -93,9 +95,13 @@ def _process_posts(subreddit: str, posts: List[dict]) -> Tuple[int, Optional[dat
         rejected = 0
         earliest_dt: Optional[datetime] = None
         for post in posts:
-            normalized, reason = normalize_post(post)
             created_dt = datetime.fromtimestamp(int(post.get("created_utc", 0)), tz=timezone.utc)
             fullname = post.get("name") or f"t3_{post.get('id')}"
+            if int(post.get("ups") or post.get("score") or 0) < MIN_UPVOTES:
+                rejected += 1
+                record_rejection(session, fullname, subreddit, "low_upvotes", post)
+                continue
+            normalized, reason = normalize_post(post)
             if normalized:
                 if is_fuzzy_duplicate(session, subreddit, normalized.title, normalized.body):
                     duplicates += 1

--- a/services/reddit_ingestor/worker.py
+++ b/services/reddit_ingestor/worker.py
@@ -1,0 +1,77 @@
+"""Worker that processes queued reddit ingestion jobs."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+
+import typer
+from sqlmodel import Session, select, create_engine
+
+from apps.api.models import Job
+from shared.config import settings
+
+from .backfill import orchestrate_backfill
+from .incremental import fetch_incremental
+
+app = typer.Typer(add_completion=False)
+
+
+def _process(session: Session) -> bool:
+    job = (
+        session.exec(
+            select(Job)
+            .where(Job.status == "queued", Job.kind.in_(["reddit_backfill", "reddit_incremental"]))
+            .order_by(Job.created_at)
+            .limit(1)
+        ).first()
+    )
+    if not job:
+        return False
+
+    job.status = "running"
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+
+    payload = job.payload or {}
+    subreddit = payload.get("subreddit")
+    try:
+        if job.kind == "reddit_backfill":
+            earliest_str = payload.get("earliest")
+            earliest_ts = None
+            if earliest_str:
+                earliest_ts = int(
+                    datetime.fromisoformat(earliest_str).replace(tzinfo=timezone.utc).timestamp()
+                )
+            inserted = orchestrate_backfill(subreddit, earliest_target_utc=earliest_ts)
+            job.result = {"inserted": inserted}
+        else:
+            inserted = fetch_incremental(subreddit)
+            job.result = {"inserted": inserted}
+        job.status = "success"
+    except Exception as exc:  # pragma: no cover - error path
+        job.status = "failed"
+        job.result = {"error": str(exc)}
+
+    session.add(job)
+    session.commit()
+    # log payload for debugging
+    print(json.dumps(job.result))
+    return True
+
+
+@app.command()
+def run(interval: float = 1.0) -> None:
+    """Continuously process queued reddit ingestion jobs."""
+    engine = create_engine(settings.DATABASE_URL, echo=False)
+    while True:
+        with Session(engine) as session:
+            processed = _process(session)
+        if not processed:
+            time.sleep(interval)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()


### PR DESCRIPTION
## Summary
- add FastAPI endpoints and admin token auth for Reddit ingestion, job listing, and promotion
- create worker process and Next.js admin page to trigger and monitor Reddit jobs
- document Reddit ingestion workflow and environment variables

## Testing
- `uv run --with pytest,httpx pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a60021d88332882b16baeac21379