### PR TITLE
Setup deterministic stack with migrations

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # App
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
-ADMIN_API_TOKEN=changeme
+ADMIN_API_TOKEN=local-admin
 
 # DB/Queue
 DATABASE_URL=postgresql+psycopg://postgres:postgres@postgres:5432/darklife

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,53 @@
-.PHONY: init sync test up down logs renderer uploader ingest backfill rebuild smoke
+.RECIPEPREFIX := >
+.PHONY: init sync test up down logs api web renderer uploader ingest backfill rebuild migrate smoke
 
 VENV_DIR := .venv
 COMPOSE := docker compose -f infra/docker-compose.yml
 
 init:
-	command -v uv >/dev/null 2>&1 || { echo "uv is required but not installed. See https://github.com/astral-sh/uv"; exit 1; }
-	[ -d $(VENV_DIR) ] || uv venv $(VENV_DIR)
-	uv sync
-	@echo "Virtual environment ready. Activate with: . $(VENV_DIR)/bin/activate"
+>command -v uv >/dev/null 2>&1 || { echo "uv is required but not installed. See https://github.com/astral-sh/uv"; exit 1; }
+>[ -d $(VENV_DIR) ] || uv venv $(VENV_DIR)
+>uv sync
+>@echo "Virtual environment ready. Activate with: . $(VENV_DIR)/bin/activate"
 
 sync:
-	uv sync
+>uv sync
 
 test:
-	uv run --with pytest,httpx pytest -q
+>uv run --with pytest,httpx pytest -q
 
 up:
-	$(COMPOSE) up -d postgres redis api web
+>$(COMPOSE) up -d postgres redis api web
 
 down:
-	$(COMPOSE) down
+>$(COMPOSE) down
 
 logs:
-	$(COMPOSE) logs -f
+>$(COMPOSE) logs -f
+
+api:
+>$(COMPOSE) up api
+
+web:
+>$(COMPOSE) up web
 
 renderer:
-	$(COMPOSE) up -d renderer
+>$(COMPOSE) up -d renderer
 
 uploader:
-	$(COMPOSE) run --rm uploader
+>$(COMPOSE) run --rm uploader
 
 ingest:
-	$(COMPOSE) --profile ops run --rm reddit_ingestor incremental
+>$(COMPOSE) --profile ops run --rm reddit_ingestor incremental
 
 backfill:
-	$(COMPOSE) --profile ops run --rm reddit_ingestor backfill
+>$(COMPOSE) --profile ops run --rm reddit_ingestor backfill
 
 rebuild:
-	$(COMPOSE) build --no-cache
+>$(COMPOSE) build --no-cache
+
+migrate:
+>$(COMPOSE) run --rm api alembic upgrade head
 
 smoke:
-	python scripts/smoke_e2e.py
+>API_BASE=http://localhost:8000 python scripts/smoke_e2e.py

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = apps/api/alembic
+sqlalchemy.url = postgresql+psycopg://postgres:postgres@postgres:5432/darklife
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(name)s %(message)s

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY apps/api/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
+COPY alembic.ini /app/alembic.ini
 COPY apps/api /app/apps/api
 COPY services/reddit_ingestor /app/services/reddit_ingestor
 COPY shared /app/shared

--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+from apps.api import models  # noqa: F401
+from shared.config import settings
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = SQLModel.metadata
+
+def run_migrations_offline() -> None:
+    url = settings.DATABASE_URL
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        {"sqlalchemy.url": settings.DATABASE_URL},
+        prefix="",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/api/alembic/versions/0001_initial.py
+++ b/apps/api/alembic/versions/0001_initial.py
@@ -1,0 +1,21 @@
+"""Initial database tables."""
+
+from alembic import op
+from sqlmodel import SQLModel
+
+from apps.api import models  # noqa: F401
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    SQLModel.metadata.create_all(bind)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    SQLModel.metadata.drop_all(bind)

--- a/apps/api/reddit_admin.py
+++ b/apps/api/reddit_admin.py
@@ -17,8 +17,12 @@ router = APIRouter(prefix="/admin/reddit", tags=["admin-reddit"])
 
 ADMIN_TOKEN = os.getenv("ADMIN_API_TOKEN")
 
-def require_token(x_admin_token: str = Header(..., alias="X-Admin-Token")) -> None:
-    if not ADMIN_TOKEN or x_admin_token != ADMIN_TOKEN:
+
+def require_token(authorization: str = Header(...)) -> None:
+    if not ADMIN_TOKEN or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    token = authorization.split(" ", 1)[1]
+    if token != ADMIN_TOKEN:
         raise HTTPException(status_code=401, detail="Unauthorized")
 
 

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn[standard]
 sqlmodel
-psycopg2-binary
+psycopg[binary]>=3.1
 redis
 praw
 requests
@@ -20,3 +20,4 @@ google-api-python-client
 google-auth-oauthlib
 langdetect
 prometheus_client
+alembic

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   postgres:
     image: postgres:15
@@ -26,8 +25,8 @@ services:
 
   api:
     build:
-      context: ..
-      dockerfile: apps/api/Dockerfile
+      context: ../apps/api
+      dockerfile: Dockerfile
     env_file: ../.env
     ports:
       - "8000:8000"
@@ -60,8 +59,8 @@ services:
 
   renderer:
     build:
-      context: ..
-      dockerfile: services/renderer/Dockerfile
+      context: ../services/renderer
+      dockerfile: Dockerfile
     env_file: ../.env
     volumes:
       - ../output:/output
@@ -74,8 +73,8 @@ services:
 
   uploader:
     build:
-      context: ..
-      dockerfile: services/uploader/Dockerfile
+      context: ../services/uploader
+      dockerfile: Dockerfile
     env_file: ../.env
     volumes:
       - ../output:/output

--- a/shared/config.py
+++ b/shared/config.py
@@ -36,7 +36,7 @@ class Settings(BaseSettings):
         description="Path to stored YouTube OAuth token",
     )
     DATABASE_URL: str = Field(
-        default="postgresql://postgres:postgres@localhost:5432/darklife",
+        default="postgresql+psycopg://postgres:postgres@postgres:5432/darklife",
         description="Postgres connection string",
     )
 


### PR DESCRIPTION
## Summary
- switch API to psycopg3 and add Alembic migrations
- document local runbook and sample env values
- use Authorization bearer token for admin endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `docker compose -f infra/docker-compose.yml build --no-cache api` *(fails: command not found: docker)*
- `make migrate` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898e04b2e288332b11e1ef90fa32f09