### PR TITLE
Fix Docker build contexts for app services

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,8 +25,8 @@ services:
 
   api:
     build:
-      context: ../apps/api
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: apps/api/Dockerfile
     env_file: ../.env
     ports:
       - "8000:8000"
@@ -59,8 +59,8 @@ services:
 
   renderer:
     build:
-      context: ../services/renderer
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: services/renderer/Dockerfile
     env_file: ../.env
     volumes:
       - ../output:/output
@@ -73,8 +73,8 @@ services:
 
   uploader:
     build:
-      context: ../services/uploader
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: services/uploader/Dockerfile
     env_file: ../.env
     volumes:
       - ../output:/output


### PR DESCRIPTION
## Summary
- point API, renderer, and uploader builds at repository root so Dockerfiles can copy shared resources

## Testing
- `docker-compose -f infra/docker-compose.yml build api renderer uploader` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_6898e336d0e88332984e9218dd1776fe