### PR TITLE
Fix Reddit ingestor backfill target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ uploader:
 >$(COMPOSE) run --rm uploader
 
 ingest:
->$(COMPOSE) --profile ops run --rm reddit_ingestor incremental
+>$(COMPOSE) --profile ops run --rm reddit_ingestor incremental --subreddits $(SUBS)
 
 backfill:
->$(COMPOSE) --profile ops run --rm reddit_ingestor backfill
+>$(COMPOSE) --profile ops run --rm reddit_ingestor backfill --subreddits $(SUBS) --earliest $(EARLIEST)
 
 rebuild:
 >$(COMPOSE) build --no-cache

--- a/services/reddit_ingestor/Dockerfile
+++ b/services/reddit_ingestor/Dockerfile
@@ -13,6 +13,7 @@ ENV REDDIT_CLIENT_ID= \
     REDDIT_USER_AGENT=darklife/1.0 \
     REDDIT_DEFAULT_SUBREDDITS=
 
-CMD ["python", "services/reddit_ingestor/cli.py", "incremental", "--subreddits", "$REDDIT_DEFAULT_SUBREDDITS"]
+ENTRYPOINT ["python", "services/reddit_ingestor/cli.py"]
+CMD ["incremental"]
 
 HEALTHCHECK CMD python -c "exit(0)"


### PR DESCRIPTION
## Summary
- route reddit_ingestor container through CLI entrypoint
- allow Makefile ingest/backfill targets to specify subreddits and earliest date

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6898ef19d2348332a85ee98f5f9bf3bd