### PR TITLE
Default Reddit creds and env wiring for ingestor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ uploader:
 >$(COMPOSE) run --rm uploader
 
 ingest:
->$(COMPOSE) --profile ops run --rm reddit_ingestor incremental --subreddits $(SUBS)
+>$(COMPOSE) --profile ops run --rm --env-file .env reddit_ingestor incremental --subreddits $(SUBS)
 
 backfill:
->$(COMPOSE) --profile ops run --rm reddit_ingestor backfill --subreddits $(SUBS) --earliest $(EARLIEST)
+>$(COMPOSE) --profile ops run --rm --env-file .env reddit_ingestor backfill --subreddits $(SUBS) --earliest $(EARLIEST)
 
 rebuild:
 >$(COMPOSE) build --no-cache

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -87,7 +87,8 @@ services:
     build:
       context: ..
       dockerfile: services/reddit_ingestor/Dockerfile
-    env_file: ../.env
+    env_file:
+      - ../.env
     depends_on:
       api:
         condition: service_healthy

--- a/services/reddit_ingestor/client.py
+++ b/services/reddit_ingestor/client.py
@@ -2,11 +2,28 @@ import logging
 from typing import Iterable, List, Dict, Any, Optional
 import praw
 
+from shared.config import settings
+
+
 log = logging.getLogger(__name__)
 
 
 class RedditClient:
-    def __init__(self, client_id: str, client_secret: str, user_agent: str):
+    def __init__(
+        self,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        user_agent: Optional[str] = None,
+    ) -> None:
+        """Create a PRAW Reddit client using env defaults when not provided."""
+
+        client_id = client_id or settings.REDDIT_CLIENT_ID
+        client_secret = client_secret or settings.REDDIT_CLIENT_SECRET
+        user_agent = user_agent or settings.REDDIT_USER_AGENT
+
+        if not all([client_id, client_secret, user_agent]):
+            raise ValueError("Reddit API credentials are required")
+
         self._r = praw.Reddit(
             client_id=client_id,
             client_secret=client_secret,


### PR DESCRIPTION
## Summary
- Use shared settings as default credentials for `RedditClient`
- Pass `.env` into `reddit_ingestor` via docker-compose and Makefile

## Testing
- `make test`
- `docker compose -f infra/docker-compose.yml build reddit_ingestor` *(fails: unknown shorthand flag: 'f')*
- `make ingest SUBS="nosleep,confession"` *(fails: unknown shorthand flag: 'f')*

------
https://chatgpt.com/codex/tasks/task_e_6899122962f48332b37fff86303cf152