### PR TITLE
Fix Alembic migrations with PYTHONPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Monorepo for automating short-form dark storytelling videos.
    - Database connection errors → `DATABASE_URL` must use host `postgres`
    - `8000` in use → change host mapping to `8001:8000`
 
+## Running Migrations
+
+Run database migrations from the repository root once your `.env` is configured:
+
+```bash
+docker compose -f infra/docker-compose.yml run --rm api sh -lc 'cd apps/api && alembic upgrade head'
+```
+
 ### Admin endpoints
 
 Admin APIs require `Authorization: Bearer $ADMIN_API_TOKEN`.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -17,6 +17,8 @@ COPY apps/api /app/apps/api
 COPY services/reddit_ingestor /app/services/reddit_ingestor
 COPY shared /app/shared
 
+ENV PYTHONPATH=/app
+
 ENV PORT=8000 \
     DATABASE_URL= \
     REDIS_URL= \

--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]  # /app
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlmodel import SQLModel
 
+# now this import should work
 from apps.api import models  # noqa: F401
 from shared.config import settings
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -27,7 +27,11 @@ services:
     build:
       context: ..
       dockerfile: apps/api/Dockerfile
-    env_file: ../.env
+    working_dir: /app/apps/api
+    env_file:
+      - ../.env
+    environment:
+      - PYTHONPATH=/app
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- ensure API Docker image and compose service include `/app` on `PYTHONPATH`
- add sys.path bootstrap in Alembic env so migrations can import `apps.api.models`
- document how to run database migrations

## Testing
- `make test`
- `docker compose -f infra/docker-compose.yml build api` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `docker compose -f infra/docker-compose.yml run --rm api sh -lc 'cd apps/api && alembic upgrade head'` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `make up` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68991aed9ed88332b883ae14dfa35eec