### PR TITLE
fix: ensure migrations use Alembic config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ rebuild:
 >$(COMPOSE) build --no-cache
 
 migrate:
->$(COMPOSE) run --rm api alembic upgrade head
+>$(COMPOSE) run --rm api alembic -c /app/alembic.ini upgrade head
 
 smoke:
 >API_BASE=http://localhost:8000 python scripts/smoke_e2e.py


### PR DESCRIPTION
## Summary
- fix migrate target to point Alembic at /app/alembic.ini

## Testing
- `make test`
- `make migrate` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68991ed48a1c8332985fe49b4064b504