### PR TITLE
fix: add build tools for API image

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    git \
+    cmake \
     ffmpeg \
     libmagic1 \
     curl \


### PR DESCRIPTION
## Summary
- install git and cmake in API Docker image for dependencies built from source

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'psycopg')*

------
https://chatgpt.com/codex/tasks/task_e_6899b7b5c2d88332b03df63b5e06a285