### PR TITLE
Ensure compose uses project .env file

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -28,8 +28,7 @@ services:
       context: ..
       dockerfile: apps/api/Dockerfile
     working_dir: /app/apps/api
-    env_file:
-      - ../.env
+    env_file: ../.env
     environment:
       - PYTHONPATH=/app
     ports:
@@ -91,8 +90,7 @@ services:
     build:
       context: ..
       dockerfile: services/reddit_ingestor/Dockerfile
-    env_file:
-      - ../.env
+    env_file: ../.env
     depends_on:
       api:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Point API and Reddit ingestor services at the repository's `.env` file

## Testing
- `pip install httpx`
- `pytest`
- `cp .env.sample .env && docker compose -f infra/docker-compose.yml config && rm .env`


------
https://chatgpt.com/codex/tasks/task_e_6899bf1da5948332828c4ecdcd63b3ff