### PR TITLE
fix: correct health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Monorepo for automating short-form dark storytelling videos.
 
 4. **Open services**
    - Web: <http://localhost:3000>
-   - API health: <http://localhost:8000/health>
+   - API health: <http://localhost:8000/readyz>
 
 5. **Renderer & uploader**
    ```bash

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -32,4 +32,4 @@ EXPOSE 8000
 
 CMD ["uvicorn", "apps.api.main:app", "--host", "0.0.0.0", "--port", "8000"]
 
-HEALTHCHECK CMD curl -f http://localhost:8000/health || exit 1
+HEALTHCHECK CMD curl -f http://localhost:8000/healthz || exit 1

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5,11 +5,11 @@
     "version": "0.1.0"
   },
   "paths": {
-    "/health": {
+    "/healthz": {
       "get": {
         "summary": "Health",
         "description": "Simple health check endpoint.",
-        "operationId": "health_health_get",
+        "operationId": "health_healthz_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -20,7 +20,7 @@
                     "type": "string"
                   },
                   "type": "object",
-                  "title": "Response Health Health Get"
+                  "title": "Response Health Healthz Get"
                 }
               }
             }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/readyz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/packages/shared-types/src/services/DefaultService.ts
+++ b/packages/shared-types/src/services/DefaultService.ts
@@ -15,7 +15,7 @@ export class DefaultService {
     public static healthHealthGet(): CancelablePromise<Record<string, string>> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/health',
+            url: '/healthz',
         });
     }
 }


### PR DESCRIPTION
## Summary
- fix Docker health checks to use API healthz/readyz endpoints
- update generated API types and docs for healthz endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899fdb953788332babf59609c29b280