### PR TITLE
fix backfill start constant

### DIFF
--- a/services/reddit_ingestor/backfill.py
+++ b/services/reddit_ingestor/backfill.py
@@ -46,6 +46,7 @@ from shared.config import settings
 
 logger = logging.getLogger(__name__)
 MIN_UPVOTES = int(os.getenv("REDDIT_MIN_UPVOTES", "0"))
+DEFAULT_BACKFILL_START = dt.datetime(2023, 1, 1, tzinfo=timezone.utc)
 
 # ---------------------------------------------------------------------------
 # ``reddit_fetch_state`` table (minimal definition for updates)
@@ -236,11 +237,12 @@ class BackfillResult:
     earliest: Optional[datetime]
 
 
-def orchestrate_backfill(subreddit: str, earliest_iso: str) -> Dict[str, Any]:
+def orchestrate_backfill(
+    subreddit: str, earliest_target_utc: Optional[int] = None
+) -> Dict[str, Any]:
     """Bounded backfill using ``new`` listing with optional cloudsearch windows."""
 
-    earliest_dt = dt.datetime.fromisoformat(earliest_iso)
-    earliest_ts = int(earliest_dt.timestamp())
+    earliest_ts = earliest_target_utc or int(DEFAULT_BACKFILL_START.timestamp())
 
     rc = RedditClient(
         client_id=settings.REDDIT_CLIENT_ID,
@@ -341,4 +343,9 @@ def orchestrate_backfill(subreddit: str, earliest_iso: str) -> Dict[str, Any]:
     }
 
 
-__all__ = ["backfill_by_window", "orchestrate_backfill", "BackfillResult"]
+__all__ = [
+    "backfill_by_window",
+    "orchestrate_backfill",
+    "BackfillResult",
+    "DEFAULT_BACKFILL_START",
+]

--- a/services/reddit_ingestor/cli.py
+++ b/services/reddit_ingestor/cli.py
@@ -12,20 +12,17 @@ This module exposes a small Typer based CLI with three commands:
   entries.
 """
 
-from datetime import datetime, timezone
 from typing import List
 import os
 
 import typer
 from sqlalchemy import func, select
 
-from .backfill import orchestrate_backfill
+from .backfill import orchestrate_backfill, DEFAULT_BACKFILL_START
 from .incremental import fetch_incremental
 from .storage import reddit_posts, run_with_session
 
 app = typer.Typer(add_completion=False, help="Reddit ingestion commands")
-
-DEFAULT_BACKFILL_START = datetime(2023, 1, 1, tzinfo=timezone.utc)
 
 
 def _subreddits_from_env() -> List[str]:
@@ -46,12 +43,11 @@ def backfill() -> None:
     """Backfill historical posts for default subreddits."""
 
     subs = _subreddits_from_env()
-    earliest_ts = int(DEFAULT_BACKFILL_START.timestamp())
     for sub in subs:
         typer.echo(
             f"Backfilling {sub} starting from {DEFAULT_BACKFILL_START.date()}..."
         )
-        inserted = orchestrate_backfill(sub, earliest_target_utc=earliest_ts)
+        inserted = orchestrate_backfill(sub)
         typer.echo(f"Inserted {inserted} posts for r/{sub}")
 
 


### PR DESCRIPTION
## Summary
- centralize default backfill start date
- let `orchestrate_backfill` accept a unix timestamp
- update CLI to rely on shared constant

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0b79e3ac8332b0e372cbc251b78b