### PR TITLE
refactor: drop postgres dependency from reddit ingestor

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -94,8 +94,6 @@ services:
     depends_on:
       api:
         condition: service_healthy
-      postgres:
-        condition: service_healthy
     profiles:
       - ops
 


### PR DESCRIPTION
## Summary
- avoid waiting on postgres when starting reddit_ingestor

## Testing
- `pytest` *(fails: psycopg.OperationalError: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_689a7b323cbc8332a5474396870308dd