### PR TITLE
chore: add ingestor API base URL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # App
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 ADMIN_API_TOKEN=local-admin
+API_BASE_URL=http://api:8000 # required by ingestor
 
 # DB/Queue
 DATABASE_URL=postgresql+psycopg://postgres:postgres@postgres:5432/darklife


### PR DESCRIPTION
## Summary
- document API_BASE_URL env var required by ingestor

## Testing
- `make test` *(fails: psycopg.OperationalError - Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_689a7ce2f8e08332a90e66ecf65fd777