### PR TITLE
Add mode column for Reddit fetch state

### DIFF
--- a/apps/api/reddit_admin.py
+++ b/apps/api/reddit_admin.py
@@ -42,6 +42,7 @@ reddit_fetch_state = Table(
     Column("subreddit", Text, unique=True, nullable=False),
     Column("last_fullname", Text),
     Column("last_created_utc", DateTime(timezone=True)),
+    Column("mode", Text),
     Column("backfill_earliest_utc", DateTime(timezone=True)),
     Column("updated_at", DateTime(timezone=True), server_default=func.now(), onupdate=func.now()),
 )
@@ -113,6 +114,7 @@ def fetch_state(
         reddit_fetch_state.c.subreddit,
         reddit_fetch_state.c.last_fullname,
         reddit_fetch_state.c.last_created_utc,
+        reddit_fetch_state.c.mode,
         reddit_fetch_state.c.backfill_earliest_utc,
         reddit_fetch_state.c.updated_at,
     )


### PR DESCRIPTION
## Summary
- add `mode` column to `reddit_fetch_state` table
- return and upsert `mode` along with other state fields

## Testing
- `uv run --with psycopg,pytest,httpx pytest -q` *(fails: psycopg.OperationalError: [Errno -2] Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_689a7e4f9134833283f2f0a920e8ffaf