### PR TITLE
Add reddit fetch state migration and doc note

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Monorepo for automating short-form dark storytelling videos.
    ```
    Fill any optional API keys and secrets. `ADMIN_API_TOKEN` defaults to `local-admin`.
 
-3. **Build & start**
+3. **Migrate & start**
    ```bash
    docker compose -f infra/docker-compose.yml build
+   make migrate   # apply migrations before starting the API
    make up
-   make migrate
    ```
 
 4. **Open services**
@@ -41,7 +41,7 @@ Monorepo for automating short-form dark storytelling videos.
 
 ## Running Migrations
 
-Run database migrations from the repository root once your `.env` is configured:
+Run database migrations from the repository root once your `.env` is configured, before starting the API:
 
 ```bash
 docker compose -f infra/docker-compose.yml run --rm api sh -lc 'cd apps/api && alembic upgrade head'

--- a/apps/api/alembic/versions/0002_reddit_fetch_state.py
+++ b/apps/api/alembic/versions/0002_reddit_fetch_state.py
@@ -1,0 +1,32 @@
+"""Add reddit_fetch_state table."""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+revision = "0002_reddit_fetch_state"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reddit_fetch_state",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column("subreddit", sa.Text(), nullable=False, unique=True),
+        sa.Column("last_fullname", sa.Text(), nullable=True),
+        sa.Column("last_created_utc", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("mode", sa.Text(), nullable=True),
+        sa.Column("backfill_earliest_utc", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("reddit_fetch_state")


### PR DESCRIPTION
## Summary
- add Alembic revision creating `reddit_fetch_state` table
- note that migrations must run before starting the API

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'psycopg')*

------
https://chatgpt.com/codex/tasks/task_e_689a800125f88332a7d59a42958fdfb9