### PR TITLE
Run migrations from apps/api directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ rebuild:
 >$(COMPOSE) build --no-cache
 
 migrate:
->$(COMPOSE) run --rm api alembic -c /app/alembic.ini upgrade head
+>$(COMPOSE) run --rm api sh -lc 'cd apps/api && alembic -c ../../alembic.ini upgrade head'
 
 smoke:
 >API_BASE=http://localhost:8000 python scripts/smoke_e2e.py


### PR DESCRIPTION
## Summary
- run migrations from apps/api directory using root alembic.ini

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'psycopg')*
- `make migrate` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b10ad5a588332b736877a61292d15