### PR TITLE
Proxy API requests through Next.js /api with mock data

### DIFF
--- a/apps/web/src/app/api/mock-data.ts
+++ b/apps/web/src/app/api/mock-data.ts
@@ -1,0 +1,44 @@
+export interface Image {
+  id: number;
+  remote_url: string;
+  selected: boolean;
+  rank: number;
+}
+
+export interface Story {
+  id: number;
+  title: string;
+  body_md: string;
+  status: "draft" | "approved";
+  images: Image[];
+}
+
+export const stories: Story[] = [
+  {
+    id: 1,
+    title: "First mock story",
+    body_md: "Lorem ipsum dolor sit amet.",
+    status: "draft",
+    images: [
+      { id: 1, remote_url: "https://placekitten.com/200/200", selected: false, rank: 0 },
+      { id: 2, remote_url: "https://placekitten.com/210/200", selected: false, rank: 1 }
+    ]
+  },
+  {
+    id: 2,
+    title: "Second mock story",
+    body_md: "Another mock story body.",
+    status: "approved",
+    images: []
+  }
+];
+
+export function nextStoryId(): number {
+  return stories.length ? Math.max(...stories.map((s) => s.id)) + 1 : 1;
+}
+
+export function nextImageId(story: Story): number {
+  return story.images.length
+    ? Math.max(...story.images.map((i) => i.id)) + 1
+    : 1;
+}

--- a/apps/web/src/app/api/stories/[id]/enqueue-render/route.ts
+++ b/apps/web/src/app/api/stories/[id]/enqueue-render/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function POST() {
+  return NextResponse.json({ id: "mock-job", status: "queued" });
+}

--- a/apps/web/src/app/api/stories/[id]/fetch-images/route.ts
+++ b/apps/web/src/app/api/stories/[id]/fetch-images/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { stories, nextImageId } from "../../../../mock-data";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const story = stories.find((s) => s.id === Number(params.id));
+  if (!story) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  if (story.images.length === 0) {
+    const first = nextImageId(story);
+    story.images.push(
+      {
+        id: first,
+        remote_url: "https://placekitten.com/200/200",
+        selected: false,
+        rank: 0,
+      },
+      {
+        id: first + 1,
+        remote_url: "https://placekitten.com/210/200",
+        selected: false,
+        rank: 1,
+      }
+    );
+  }
+  return NextResponse.json(story.images);
+}

--- a/apps/web/src/app/api/stories/[id]/images/[imageId]/route.ts
+++ b/apps/web/src/app/api/stories/[id]/images/[imageId]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { stories } from "../../../../mock-data";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string; imageId: string } }
+) {
+  const story = stories.find((s) => s.id === Number(params.id));
+  if (!story) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  const image = story.images.find((i) => i.id === Number(params.imageId));
+  if (!image) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  const patch = await req.json();
+  Object.assign(image, patch);
+  return NextResponse.json(image);
+}

--- a/apps/web/src/app/api/stories/[id]/images/route.ts
+++ b/apps/web/src/app/api/stories/[id]/images/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { stories } from "../../../mock-data";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const story = stories.find((s) => s.id === Number(params.id));
+  if (!story) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(story.images);
+}

--- a/apps/web/src/app/api/stories/[id]/route.ts
+++ b/apps/web/src/app/api/stories/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { stories } from "../../mock-data";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const story = stories.find((s) => s.id === Number(params.id));
+  if (!story) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(story);
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const story = stories.find((s) => s.id === Number(params.id));
+  if (!story) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  const patch = await req.json();
+  Object.assign(story, patch);
+  return NextResponse.json(story);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const index = stories.findIndex((s) => s.id === Number(params.id));
+  if (index === -1) {
+    return NextResponse.json({ message: "Not found" }, { status: 404 });
+  }
+  stories.splice(index, 1);
+  return NextResponse.json({});
+}

--- a/apps/web/src/app/api/stories/[id]/split/route.ts
+++ b/apps/web/src/app/api/stories/[id]/split/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { stories } from "../../../../mock-data";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const story = stories.find((s) => s.id === Number(params.id));
+  if (!story) {
+    return NextResponse.json([], { status: 404 });
+  }
+  const part = {
+    id: 1,
+    index: 0,
+    body_md: story.body_md,
+    est_seconds: Math.ceil(story.body_md.length / 5),
+  };
+  return NextResponse.json([part]);
+}

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { stories, nextStoryId, Story } from "../mock-data";
+
+export async function GET() {
+  const list = stories.map(({ id, title }) => ({ id, title }));
+  return NextResponse.json(list);
+}
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const story: Story = {
+    id: nextStoryId(),
+    title: body.title ?? "Untitled story",
+    body_md: body.body_md ?? "",
+    status: "draft",
+    images: [],
+  };
+  stories.push(story);
+  return NextResponse.json(story, { status: 201 });
+}

--- a/apps/web/src/app/stories/page.tsx
+++ b/apps/web/src/app/stories/page.tsx
@@ -33,13 +33,13 @@ export default function StoriesPage() {
       if (q) params.set("q", q);
       params.set("page", String(page));
       params.set("limit", String(limit));
-      return apiFetch<Story[]>(`/stories?${params.toString()}`);
+      return apiFetch<Story[]>(`/api/stories?${params.toString()}`);
     },
   });
 
   const createMutation = useMutation({
     mutationFn: () =>
-      apiFetch<Story>("/stories", {
+      apiFetch<Story>("/api/stories", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: "Untitled story" }),
@@ -53,7 +53,8 @@ export default function StoriesPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: number) => apiFetch(`/stories/${id}`, { method: "DELETE" }),
+    mutationFn: (id: number) =>
+      apiFetch(`/api/stories/${id}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["stories"] });
       showToast({ type: "success", message: "Story deleted" });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,7 +1,5 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
-
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, init);
+  const res = await fetch(path, init);
   if (!res.ok) {
     throw new Error(`API request failed with ${res.status}`);
   }


### PR DESCRIPTION
## Summary
- Route client API calls through Next.js `/api` to avoid CORS issues
- Add mock story data and API routes for stories and related actions
- Support creating and deleting stories via the new proxy endpoints

## Testing
- `pnpm --filter web lint` *(fails: React Hook useEffect missing dependency; Unexpected any)*
- `pnpm --filter web exec eslint src/lib/api.ts src/app/stories/page.tsx "src/app/api/**/*.ts" -f json` *(pass)*
- `pnpm --filter web exec eslint "src/app/api/stories/[id]/route.ts" -f json` *(pass)*

------
https://chatgpt.com/codex/tasks/task_e_689b38457aa483328582336344acdf83