### PR TITLE
Use Next.js proxy for frontend API requests

### DIFF
--- a/apps/web/.env.sample
+++ b/apps/web/.env.sample
@@ -1,2 +1,3 @@
 # Environment variables for the web frontend
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+API_BASE_URL=http://api:8000
+ADMIN_API_TOKEN=changeme

--- a/apps/web/src/app/admin/reddit/page.tsx
+++ b/apps/web/src/app/admin/reddit/page.tsx
@@ -2,9 +2,6 @@
 
 import { useEffect, useState } from "react";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-const ADMIN_TOKEN = process.env.NEXT_PUBLIC_ADMIN_TOKEN || "";
-
 interface Job {
   id: number;
   subreddit: string;
@@ -38,14 +35,12 @@ export default function RedditAdminPage() {
   const [posts, setPosts] = useState<PostRow[]>([]);
   const [selected, setSelected] = useState<Record<string, boolean>>({});
 
-  const headers = { "X-Admin-Token": ADMIN_TOKEN };
-
   async function refresh() {
-    const s = await fetch(`${API_BASE}/api/admin/reddit/state`, { headers }).then((r) => r.json());
+    const s = await fetch(`/api/admin/reddit/state`).then((r) => r.json());
     setState(s);
-    const j = await fetch(`${API_BASE}/api/admin/reddit/jobs`, { headers }).then((r) => r.json());
+    const j = await fetch(`/api/admin/reddit/jobs`).then((r) => r.json());
     setJobs(j);
-    const p = await fetch(`${API_BASE}/api/admin/reddit/posts`, { headers }).then((r) => r.json());
+    const p = await fetch(`/api/admin/reddit/posts`).then((r) => r.json());
     setPosts(p);
   }
 
@@ -54,18 +49,18 @@ export default function RedditAdminPage() {
   }, []);
 
   async function runIncremental() {
-    await fetch(`${API_BASE}/api/admin/reddit/incremental`, {
+    await fetch(`/api/admin/reddit/incremental`, {
       method: "POST",
-      headers: { ...headers, "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ subreddits: subs.split(",").map((s) => s.trim()).filter(Boolean) }),
     });
     refresh();
   }
 
   async function runBackfill() {
-    await fetch(`${API_BASE}/api/admin/reddit/backfill`, {
+    await fetch(`/api/admin/reddit/backfill`, {
       method: "POST",
-      headers: { ...headers, "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ subreddits: subs.split(",").map((s) => s.trim()).filter(Boolean), earliest }),
     });
     refresh();
@@ -78,9 +73,9 @@ export default function RedditAdminPage() {
   async function promoteSelected() {
     const ids = Object.keys(selected).filter((k) => selected[k]);
     if (!ids.length) return;
-    await fetch(`${API_BASE}/api/admin/reddit/promote`, {
+    await fetch(`/api/admin/reddit/promote`, {
       method: "POST",
-      headers: { ...headers, "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ reddit_ids: ids }),
     });
     refresh();

--- a/apps/web/src/app/api/admin/reddit/[...path]/route.ts
+++ b/apps/web/src/app/api/admin/reddit/[...path]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.API_BASE_URL || "";
+const ADMIN_TOKEN = process.env.ADMIN_API_TOKEN || "";
+
+async function handler(
+  req: NextRequest,
+  { params }: { params: { path?: string[] } }
+) {
+  const path = params.path?.join("/") ?? "";
+  const url = `${API_BASE_URL}/api/admin/reddit/${path}${req.nextUrl.search}`;
+  const body = req.method === "GET" || req.method === "HEAD" ? undefined : await req.text();
+  const res = await fetch(url, {
+    method: req.method,
+    headers: {
+      ...(req.headers.get("content-type")
+        ? { "Content-Type": req.headers.get("content-type") as string }
+        : {}),
+      "X-Admin-Token": ADMIN_TOKEN,
+    },
+    body,
+  });
+  const text = await res.text();
+  return new NextResponse(text, { status: res.status, headers: res.headers });
+}
+
+export { handler as GET, handler as POST };

--- a/apps/web/src/app/stories/[id]/images-tab.tsx
+++ b/apps/web/src/app/stories/[id]/images-tab.tsx
@@ -16,7 +16,7 @@ export default function ImagesTab({ storyId }: { storyId: string }) {
   const queryClient = useQueryClient();
   const { data, isLoading } = useQuery({
     queryKey: ["images", storyId],
-    queryFn: () => apiFetch<Asset[]>(`/api/stories/${storyId}/images`),
+    queryFn: () => apiFetch<Asset[]>(`/stories/${storyId}/images`),
   });
 
   const [images, setImages] = useState<Asset[]>([]);
@@ -26,13 +26,13 @@ export default function ImagesTab({ storyId }: { storyId: string }) {
 
   const fetchMutation = useMutation({
     mutationFn: () =>
-      apiFetch(`/api/stories/${storyId}/fetch-images`, { method: "POST" }),
+      apiFetch(`/stories/${storyId}/fetch-images`, { method: "POST" }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["images", storyId] }),
   });
 
   const patchMutation = useMutation({
     mutationFn: ({ id, patch }: { id: number; patch: Partial<Asset> }) =>
-      apiFetch(`/api/stories/${storyId}/images/${id}`, {
+      apiFetch(`/stories/${storyId}/images/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(patch),

--- a/apps/web/src/app/stories/[id]/page.tsx
+++ b/apps/web/src/app/stories/[id]/page.tsx
@@ -49,7 +49,7 @@ export default function StoryEditorPage({ params }: any) {
 
   const { data: images } = useQuery({
     queryKey: ["images", id],
-    queryFn: () => apiFetch<Asset[]>(`/api/stories/${id}/images`),
+    queryFn: () => apiFetch<Asset[]>(`/stories/${id}/images`),
   });
 
   const selectedCount = images?.filter((img) => img.selected).length ?? 0;
@@ -61,7 +61,7 @@ export default function StoryEditorPage({ params }: any) {
 
   const { data, isLoading } = useQuery({
     queryKey: ["story", id],
-    queryFn: () => apiFetch<Story>(`/api/stories/${id}`),
+    queryFn: () => apiFetch<Story>(`/stories/${id}`),
   });
 
   useEffect(() => {
@@ -72,7 +72,7 @@ export default function StoryEditorPage({ params }: any) {
 
   const mutation = useMutation({
     mutationFn: (patch: Partial<Story>) =>
-      apiFetch<Story>(`/api/stories/${id}`, {
+      apiFetch<Story>(`/stories/${id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(patch),
@@ -100,7 +100,7 @@ export default function StoryEditorPage({ params }: any) {
 
   const enqueueMutation = useMutation({
     mutationFn: () =>
-      apiFetch<Job>(`/api/stories/${id}/enqueue-render`, { method: "POST" }),
+      apiFetch<Job>(`/stories/${id}/enqueue-render`, { method: "POST" }),
     onSuccess: (job) =>
       showToast({
         type: "success",
@@ -114,7 +114,7 @@ export default function StoryEditorPage({ params }: any) {
 
   const splitMutation = useMutation({
     mutationFn: () =>
-      apiFetch<StoryPart[]>(`/api/stories/${id}/split`, { method: "POST" }),
+      apiFetch<StoryPart[]>(`/stories/${id}/split`, { method: "POST" }),
     onSuccess: (data) => {
       setParts([...data].sort((a, b) => a.index - b.index));
       setTab("parts");

--- a/apps/web/src/app/stories/page.tsx
+++ b/apps/web/src/app/stories/page.tsx
@@ -33,13 +33,13 @@ export default function StoriesPage() {
       if (q) params.set("q", q);
       params.set("page", String(page));
       params.set("limit", String(limit));
-      return apiFetch<Story[]>(`/api/stories?${params.toString()}`);
+      return apiFetch<Story[]>(`/stories?${params.toString()}`);
     },
   });
 
   const createMutation = useMutation({
     mutationFn: () =>
-      apiFetch<Story>("/api/stories", {
+      apiFetch<Story>('/stories', {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: "Untitled story" }),
@@ -54,7 +54,7 @@ export default function StoriesPage() {
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) =>
-      apiFetch(`/api/stories/${id}`, { method: "DELETE" }),
+      apiFetch(`/stories/${id}`, { method: "DELETE" }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["stories"] });
       showToast({ type: "success", message: "Story deleted" });

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -6,17 +6,16 @@ beforeEach(() => {
 });
 
 describe('apiFetch', () => {
-  it('prefixes base url', async () => {
+  it('prefixes /api', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     });
     const g = globalThis as unknown as { fetch: typeof fetch };
     g.fetch = mockFetch as typeof fetch;
-    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://api';
 
     await apiFetch('/stories');
-    expect(mockFetch).toHaveBeenCalledWith('http://api/stories', undefined);
+    expect(mockFetch).toHaveBeenCalledWith('/api/stories', undefined);
   });
 
   it('throws on http error', async () => {
@@ -27,7 +26,6 @@ describe('apiFetch', () => {
     });
     const g = globalThis as unknown as { fetch: typeof fetch };
     g.fetch = mockFetch as typeof fetch;
-    process.env.NEXT_PUBLIC_API_BASE_URL = '';
 
     await expect(apiFetch('/fail')).rejects.toThrow('API request failed with 500');
   });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,6 @@
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-  const res = await fetch(`${base}${path}`, init);
+  const url = path.startsWith("/") ? `/api${path}` : `/api/${path}`;
+  const res = await fetch(url, init);
   if (!res.ok) {
     throw new Error(`API request failed with ${res.status}`);
   }


### PR DESCRIPTION
## Summary
- Prefix client requests with `/api` to ensure they go through Next.js
- Add catch-all `/api/admin/reddit` route that forwards to the API service with admin token
- Update admin and story pages plus env sample to drop direct API access

## Testing
- `pnpm --filter web test --run`
- `pnpm --filter web lint`


------
https://chatgpt.com/codex/tasks/task_e_689b534702ec83329b730878a608c6c5