### PR TITLE
fix web proxy to api

### DIFF
--- a/apps/web/src/app/api/stories/[...path]/route.ts
+++ b/apps/web/src/app/api/stories/[...path]/route.ts
@@ -10,7 +10,7 @@ async function handler(
   if (path.endsWith("/enqueue-render")) {
     path = path.replace(/\/enqueue-render$/, "/enqueue-series");
   }
-  const url = `${API_BASE_URL}/api/stories/${path}${req.nextUrl.search}`;
+  const url = `${API_BASE_URL}/stories/${path}${req.nextUrl.search}`;
   const body = req.method === "GET" || req.method === "HEAD" ? undefined : await req.text();
   const res = await fetch(url, {
     method: req.method,

--- a/apps/web/src/app/api/stories/route.test.ts
+++ b/apps/web/src/app/api/stories/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const API_URL = 'https://api.example.com';
+
+let rootGET: any;
+let rootPOST: any;
+let dynamicGET: any;
+
+function mockResponse(body: string = '[]', status = 200) {
+  return {
+    status,
+    headers: new Headers(),
+    text: () => Promise.resolve(body),
+  };
+}
+
+describe('stories API proxy routes', () => {
+  beforeAll(async () => {
+    process.env.API_BASE_URL = API_URL;
+    ({ GET: rootGET, POST: rootPOST } = await import('./route'));
+    ({ GET: dynamicGET } = await import('./[...path]/route'));
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('proxies root GET to API_BASE_URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse());
+    (globalThis as any).fetch = mockFetch;
+    const req = new NextRequest('http://localhost/api/stories');
+    await rootGET(req);
+    expect(mockFetch).toHaveBeenCalledWith(`${API_URL}/stories`);
+  });
+
+  it('proxies root POST to API_BASE_URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse('ok'));
+    (globalThis as any).fetch = mockFetch;
+    const req = new NextRequest('http://localhost/api/stories', { method: 'POST', body: '{}' });
+    await rootPOST(req);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${API_URL}/stories`,
+      expect.objectContaining({ method: 'POST', body: '{}' })
+    );
+  });
+
+  it('proxies dynamic route to API_BASE_URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse());
+    (globalThis as any).fetch = mockFetch;
+    const req = new NextRequest('http://localhost/api/stories/123');
+    await dynamicGET(req, { params: { path: ['123'] } });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${API_URL}/stories/123`,
+      expect.objectContaining({ method: 'GET', body: undefined })
+    );
+  });
+});

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 const API_BASE_URL = process.env.API_BASE_URL || "";
 
 export async function GET(req: NextRequest) {
-  const url = `${API_BASE_URL}/api/stories${req.nextUrl.search}`;
+  const url = `${API_BASE_URL}/stories${req.nextUrl.search}`;
   const res = await fetch(url);
   const text = await res.text();
   return new NextResponse(text, { status: res.status, headers: res.headers });
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const body = await req.text();
-  const res = await fetch(`${API_BASE_URL}/api/stories`, {
+  const res = await fetch(`${API_BASE_URL}/stories`, {
     method: "POST",
     headers: {
       ...(req.headers.get("content-type")


### PR DESCRIPTION
## Summary
- fix Next.js proxy to call API `/stories` endpoint
- add tests verifying proxy routing to API

## Testing
- `pnpm test`
- `pytest` *(fails: sqlalchemy.exc.OperationalError: [Errno -2] Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_689b664793b8833280493bbf2148dd61