### PR TITLE
fix: use useParams in story editor page

### DIFF
--- a/apps/web/src/app/stories/[id]/page.tsx
+++ b/apps/web/src/app/stories/[id]/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef } from "react";
+import { useParams } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiFetch } from "@/lib/api";
 import { marked } from "marked";
@@ -38,8 +39,9 @@ type Toast = {
   linkText?: string;
 };
 
-export default function StoryEditorPage({ params }: any) {
-  const { id } = params as { id: string };
+export default function StoryEditorPage() {
+  const params = useParams<{ id: string }>();
+  const { id } = params;
   const [form, setForm] = useState<Story | null>(null);
   const [toast, setToast] = useState<Toast | null>(null);
   const isInitial = useRef(true);


### PR DESCRIPTION
## Summary
- avoid Next.js sync access warning by using `useParams` in the Story editor page

## Testing
- `cd apps/web && pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_689b6bb03fbc8332bb7023c17b2debd5