### PR TITLE
fix: allow remote images in web app

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+      {
+        protocol: "http",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- allow loading remote images by configuring Next.js `images.remotePatterns`

## Testing
- `pnpm test run`
- `pnpm lint` *(fails: Unexpected any. Specify a different type.)*

------
https://chatgpt.com/codex/tasks/task_e_689b6ffeffa48332bcd7720c584ee690