### PR TITLE
Ensure renderer container can import shared modules

### DIFF
--- a/services/renderer/Dockerfile
+++ b/services/renderer/Dockerfile
@@ -11,7 +11,10 @@ COPY apps/api /app/apps/api
 COPY shared /app/shared
 COPY video_renderer /app/video_renderer
 
-ENV WHISPER_MODEL=base \
+# Ensure project packages like "shared" are importable when running
+# the poller as a script.
+ENV PYTHONPATH=/app \
+    WHISPER_MODEL=base \
     OUTPUT_DIR=/output \
     TMPDIR=/tmp/render
 


### PR DESCRIPTION
## Summary
- include project root on `PYTHONPATH` so renderer poller can import `shared`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c590ad7a88332a4dfd9ca8d7f8ebe