### PR TITLE
fix(renderer): install config deps

### DIFF
--- a/services/renderer/Dockerfile
+++ b/services/renderer/Dockerfile
@@ -4,7 +4,16 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir faster-whisper pydub typer
+# Install required Python packages for the renderer service.
+# Include config dependencies (pydantic & pydantic-settings) and
+# networking library `requests` used by the poller.
+RUN pip install --no-cache-dir \
+    faster-whisper \
+    pydub \
+    typer \
+    requests \
+    pydantic \
+    pydantic-settings
 
 COPY services/renderer /app/services/renderer
 COPY apps/api /app/apps/api


### PR DESCRIPTION
## Summary
- install `pydantic`, `pydantic-settings`, and `requests` in renderer Dockerfile so config loads

## Testing
- `pytest`
- `docker-compose -f infra/docker-compose.yml build renderer` *(fails: Connection refused to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689c5be7fba08332b0d13cfec898c3c3