### PR TITLE
feat(web): add media selection workflow

### DIFF
--- a/apps/web/e2e/inbox-review.spec.ts
+++ b/apps/web/e2e/inbox-review.spec.ts
@@ -11,4 +11,11 @@ test("inbox to review", async ({ page }) => {
   await page.goto("/story/2/split");
   await page.getByRole("button", { name: "Save" }).click();
   await expect(page.getByTestId("status")).toHaveText("Status: split");
+  await page.goto("/story/2/media");
+  await page.getByTestId("catalog-img-0").click();
+  await page.getByRole("button", { name: "Apply to all" }).click();
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByTestId("status")).toHaveText(
+    "Status: media_selected",
+  );
 });

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AppShell } from "@/components/app-shell";
+import MswProvider from "@/mocks/msw-provider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,6 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased bg-background text-foreground">
+        <MswProvider />
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/apps/web/src/app/story/[id]/media/page.tsx
+++ b/apps/web/src/app/story/[id]/media/page.tsx
@@ -1,0 +1,10 @@
+import MediaSelector from "@/components/MediaSelector";
+import { getStory } from "@/lib/stories";
+import { segmentSentences, splitSentences } from "@/lib/split";
+
+export default async function MediaPage({ params }: { params: { id: string } }) {
+  const story = await getStory(Number(params.id));
+  const sentences = segmentSentences(story.body_md || "");
+  const parts = splitSentences(sentences).map((p) => p.join(" ").trim());
+  return <MediaSelector story={story} parts={parts} />;
+}

--- a/apps/web/src/components/ImagePicker.tsx
+++ b/apps/web/src/components/ImagePicker.tsx
@@ -1,0 +1,104 @@
+"use client";
+import { useEffect, useState } from "react";
+import type { CatalogImage } from "@/lib/catalog";
+import { fetchCatalog } from "@/lib/catalog";
+
+interface Props {
+  onSelect(image: CatalogImage): void;
+}
+
+export default function ImagePicker({ onSelect }: Props) {
+  const [tab, setTab] = useState<"catalog" | "url" | "upload">("catalog");
+  const [images, setImages] = useState<CatalogImage[]>([]);
+  const [url, setUrl] = useState("");
+  const [attr, setAttr] = useState("");
+
+  useEffect(() => {
+    fetchCatalog().then(setImages).catch(() => setImages([]));
+  }, []);
+
+  const select = (img: CatalogImage) => {
+    onSelect(img);
+  };
+
+  return (
+    <div>
+      <div className="mb-2 space-x-2">
+        <button onClick={() => setTab("catalog")}>Catalog</button>
+        <button onClick={() => setTab("url")}>URL</button>
+        <button onClick={() => setTab("upload")}>Upload</button>
+      </div>
+      {tab === "catalog" && (
+        <div className="grid grid-cols-3 gap-2 max-h-60 overflow-auto">
+          {images.map((img, i) => (
+            <button
+              type="button"
+              key={i}
+              data-testid={`catalog-img-${i}`}
+              className="relative"
+              onClick={() => select(img)}
+            >
+              <img src={img.url} alt="" loading="lazy" />
+              {img.nsfw && (
+                <span className="absolute top-1 left-1 bg-red-600 text-white text-xs px-1">
+                  NSFW
+                </span>
+              )}
+              {img.attribution && (
+                <span className="absolute bottom-1 left-1 bg-black/50 text-white text-xs px-1">
+                  {img.attribution}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+      {tab === "url" && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            placeholder="Image URL"
+            className="border p-1"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="Attribution"
+            className="border p-1"
+            value={attr}
+            onChange={(e) => setAttr(e.target.value)}
+          />
+          <button
+            onClick={() =>
+              url && select({ url, attribution: attr || undefined })
+            }
+          >
+            Add
+          </button>
+        </div>
+      )}
+      {tab === "upload" && (
+        <div className="space-y-2">
+          <input
+            type="file"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) {
+                const local = URL.createObjectURL(file);
+                select({ url: local, attribution: attr || undefined });
+              }
+            }}
+          />
+          <input
+            type="text"
+            placeholder="Attribution"
+            className="border p-1"
+            value={attr}
+            onChange={(e) => setAttr(e.target.value)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/MediaSelector.tsx
+++ b/apps/web/src/components/MediaSelector.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Story } from "@/lib/stories";
+import { updateStoryStatus } from "@/lib/stories";
+import ImagePicker from "./ImagePicker";
+import type { CatalogImage } from "@/lib/catalog";
+import { selectImage, bulkApply } from "@/lib/media";
+
+export default function MediaSelector({
+  story,
+  parts,
+}: {
+  story: Story;
+  parts: string[];
+}) {
+  const router = useRouter();
+  const [status, setStatus] = useState(story.status);
+  const [images, setImages] = useState<(CatalogImage | null)[]>(
+    () => Array(parts.length).fill(null),
+  );
+
+  const handleSelect = (i: number, img: CatalogImage) => {
+    setImages((prev) => selectImage(prev, i, img));
+  };
+
+  const handleBulk = () => {
+    setImages((prev) => bulkApply(prev));
+  };
+
+  const handleSave = async () => {
+    await updateStoryStatus(story.id, "media_selected");
+    setStatus("media_selected");
+    router.refresh();
+  };
+
+  return (
+    <div>
+      <span data-testid="status">Status: {status}</span>
+      {parts.map((p, i) => (
+        <div key={i} className="mb-4">
+          <p>{p}</p>
+          {images[i]?.url && (
+            <img src={images[i]!.url} alt="" className="mb-2" />
+          )}
+          <ImagePicker onSelect={(img) => handleSelect(i, img)} />
+        </div>
+      ))}
+      <button onClick={handleBulk}>Apply to all</button>
+      <button onClick={handleSave}>Save</button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/catalog.test.ts
+++ b/apps/web/src/lib/catalog.test.ts
@@ -1,0 +1,15 @@
+import { beforeAll, afterAll, afterEach, describe, expect, it } from "vitest";
+import { server } from "../mocks/server";
+import { fetchCatalog } from "./catalog";
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("fetchCatalog", () => {
+  it("returns mocked images", async () => {
+    const images = await fetchCatalog();
+    expect(images).toHaveLength(2);
+    expect(images[0].url).toBeDefined();
+  });
+});

--- a/apps/web/src/lib/catalog.ts
+++ b/apps/web/src/lib/catalog.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const CatalogImageSchema = z.object({
+  url: z.string(),
+  nsfw: z.boolean().optional(),
+  attribution: z.string().optional(),
+});
+
+export type CatalogImage = z.infer<typeof CatalogImageSchema>;
+
+export async function fetchCatalog(): Promise<CatalogImage[]> {
+  const res = await fetch("/api/catalog");
+  if (!res.ok) {
+    throw new Error("Failed to fetch catalog");
+  }
+  const data = await res.json();
+  return z.array(CatalogImageSchema).parse(data);
+}

--- a/apps/web/src/lib/media.test.ts
+++ b/apps/web/src/lib/media.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import type { CatalogImage } from "./catalog";
+import { selectImage, bulkApply } from "./media";
+
+describe("media selection", () => {
+  it("selectImage assigns image at index", () => {
+    const img: CatalogImage = { url: "a" };
+    const res = selectImage([null, null], 1, img);
+    expect(res[1]).toEqual(img);
+  });
+  it("bulkApply copies first selection", () => {
+    const img: CatalogImage = { url: "a" };
+    const res = bulkApply([img, null, null]);
+    expect(res).toEqual([img, img, img]);
+  });
+});

--- a/apps/web/src/lib/media.ts
+++ b/apps/web/src/lib/media.ts
@@ -1,0 +1,17 @@
+import type { CatalogImage } from "./catalog";
+
+export function selectImage(
+  images: (CatalogImage | null)[],
+  index: number,
+  image: CatalogImage,
+): (CatalogImage | null)[] {
+  const next = [...images];
+  next[index] = image;
+  return next;
+}
+
+export function bulkApply(
+  images: (CatalogImage | null)[],
+): (CatalogImage | null)[] {
+  return images.map(() => images[0] ?? null);
+}

--- a/apps/web/src/mocks/browser.ts
+++ b/apps/web/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from "msw/browser";
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -1,0 +1,18 @@
+import { http, HttpResponse } from "msw";
+
+export const handlers = [
+  http.get("/api/catalog", () =>
+    HttpResponse.json([
+      {
+        url: "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBA==",
+        nsfw: false,
+        attribution: "img1",
+      },
+      {
+        url: "data:image/gif;base64,R0lGODlhAQABAIAAAAUEBA==",
+        nsfw: true,
+        attribution: "img2",
+      },
+    ]),
+  ),
+];

--- a/apps/web/src/mocks/msw-provider.tsx
+++ b/apps/web/src/mocks/msw-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useEffect } from "react";
+
+export default function MswProvider() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      import("./browser").then(({ worker }) => worker.start());
+    }
+  }, []);
+  return null;
+}

--- a/apps/web/src/mocks/server.ts
+++ b/apps/web/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from "msw/node";
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);


### PR DESCRIPTION
## Summary
- add ImagePicker with catalog, URL and upload tabs plus NSFW and attribution display
- implement media selection page and bulk apply to mark story as media_selected
- mock catalog API with MSW and extend tests for media workflow

## Testing
- `pnpm --filter web test --run`
- `pnpm --filter web e2e` *(fails: browserType.launch: Executable doesn't exist...)*


------
https://chatgpt.com/codex/tasks/task_e_689c8f5bb5648332bff61f3e3a58dee5