### PR TITLE
feat: add job queue and tracking

### DIFF
--- a/apps/web/e2e/enqueue-jobs.spec.ts
+++ b/apps/web/e2e/enqueue-jobs.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test("enqueue and view jobs", async ({ page }) => {
+  await page.goto("/story/2/queue");
+  await page.getByTestId("captions-checkbox").check();
+  await page.getByRole("button", { name: "Enqueue" }).click();
+  await expect(page).toHaveURL(/\/story\/2\/jobs/);
+  await expect(page.getByTestId("job-row").first()).toContainText("Queued");
+  await page.goto("/jobs");
+  await expect(page.getByTestId("job-row").first()).toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
+    "@tanstack/react-query": "^5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "next": "15.4.6",

--- a/apps/web/src/app/api/admin/jobs/data.ts
+++ b/apps/web/src/app/api/admin/jobs/data.ts
@@ -1,0 +1,19 @@
+export interface JobData {
+  id: number;
+  story_id: number;
+  kind: string;
+  status: string;
+}
+
+let jobs: JobData[] = [];
+let nextId = 1;
+
+export function listJobs(story_id?: number): JobData[] {
+  return story_id ? jobs.filter((j) => j.story_id === story_id) : jobs;
+}
+
+export function addJobs(items: Omit<JobData, "id">[]): JobData[] {
+  const created = items.map((it) => ({ id: nextId++, ...it }));
+  jobs.push(...created);
+  return created;
+}

--- a/apps/web/src/app/api/admin/jobs/route.ts
+++ b/apps/web/src/app/api/admin/jobs/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listJobs } from "./data";
+
+export function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const storyId = searchParams.get("story_id");
+  const jobs = listJobs(storyId ? Number(storyId) : undefined);
+  return NextResponse.json(jobs);
+}

--- a/apps/web/src/app/api/admin/stories/[id]/enqueue/route.ts
+++ b/apps/web/src/app/api/admin/stories/[id]/enqueue/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { addJobs } from "../../../jobs/data";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const jobs = addJobs([
+    { story_id: Number(params.id), kind: "render", status: "queued" },
+  ]);
+  return NextResponse.json({ jobs });
+}

--- a/apps/web/src/app/jobs/page.tsx
+++ b/apps/web/src/app/jobs/page.tsx
@@ -1,0 +1,5 @@
+import JobTable from "@/components/JobTable";
+
+export default function JobsPage() {
+  return <JobTable />;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { AppShell } from "@/components/app-shell";
 import MswProvider from "@/mocks/msw-provider";
+import QueryProvider from "@/components/query-provider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -17,7 +18,9 @@ export default function RootLayout({
     <html lang="en">
       <body className="antialiased bg-background text-foreground">
         <MswProvider />
-        <AppShell>{children}</AppShell>
+        <QueryProvider>
+          <AppShell>{children}</AppShell>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/story/[id]/jobs/page.tsx
+++ b/apps/web/src/app/story/[id]/jobs/page.tsx
@@ -1,0 +1,5 @@
+import JobTable from "@/components/JobTable";
+
+export default function StoryJobsPage({ params }: { params: { id: string } }) {
+  return <JobTable storyId={Number(params.id)} />;
+}

--- a/apps/web/src/app/story/[id]/queue/page.tsx
+++ b/apps/web/src/app/story/[id]/queue/page.tsx
@@ -1,0 +1,7 @@
+import EnqueueDialog from "@/components/EnqueueDialog";
+import { getStory } from "@/lib/stories";
+
+export default async function QueuePage({ params }: { params: { id: string } }) {
+  const story = await getStory(Number(params.id));
+  return <EnqueueDialog storyId={story.id} />;
+}

--- a/apps/web/src/components/EnqueueDialog.tsx
+++ b/apps/web/src/components/EnqueueDialog.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { enqueueStory } from "@/lib/jobs";
+
+export default function EnqueueDialog({ storyId }: { storyId: number }) {
+  const router = useRouter();
+  const [preset, setPreset] = useState("default");
+  const [captions, setCaptions] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await enqueueStory(storyId, preset, captions);
+    router.push(`/story/${storyId}/jobs`);
+  };
+
+  return (
+    <form onSubmit={submit} data-testid="enqueue-form">
+      <label>
+        Preset
+        <select
+          value={preset}
+          onChange={(e) => setPreset(e.target.value)}
+          data-testid="preset-select"
+        >
+          <option value="default">default</option>
+        </select>
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={captions}
+          onChange={(e) => setCaptions(e.target.checked)}
+          data-testid="captions-checkbox"
+        />
+        Captions
+      </label>
+      <button type="submit">Enqueue</button>
+    </form>
+  );
+}

--- a/apps/web/src/components/JobTable.tsx
+++ b/apps/web/src/components/JobTable.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { listJobs, mapJobStatus, type Job } from "@/lib/jobs";
+
+export default function JobTable({ storyId }: { storyId?: number }) {
+  const { data } = useQuery({
+    queryKey: ["jobs", storyId],
+    queryFn: () => listJobs(storyId ? { story_id: storyId } : {}),
+    refetchInterval: 2000,
+  });
+
+  const jobs = data ?? [];
+  return (
+    <table data-testid="job-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Kind</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {jobs.map((job: Job) => (
+          <tr key={job.id} data-testid="job-row">
+            <td>{job.id}</td>
+            <td>{job.kind}</td>
+            <td>{mapJobStatus(job.status)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/src/components/query-provider.tsx
+++ b/apps/web/src/components/query-provider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/apps/web/src/lib/jobs.test.ts
+++ b/apps/web/src/lib/jobs.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { mapJobStatus } from "./jobs";
+
+describe("mapJobStatus", () => {
+  it("maps known statuses", () => {
+    expect(mapJobStatus("queued")).toBe("Queued");
+    expect(mapJobStatus("running")).toBe("Running");
+    expect(mapJobStatus("done")).toBe("Done");
+    expect(mapJobStatus("error")).toBe("Error");
+  });
+  it("falls back on unknown", () => {
+    expect(mapJobStatus("mystery")).toBe("Unknown");
+  });
+});

--- a/apps/web/src/lib/jobs.ts
+++ b/apps/web/src/lib/jobs.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { apiFetch } from "./api";
+
+export const JobSchema = z.object({
+  id: z.number(),
+  story_id: z.number().nullable(),
+  kind: z.string(),
+  status: z.string(),
+});
+export type Job = z.infer<typeof JobSchema>;
+
+const JobListSchema = z.object({ jobs: z.array(JobSchema) });
+
+export async function enqueueStory(
+  id: number,
+  preset: string,
+  captions: boolean,
+): Promise<Job[]> {
+  const data = await apiFetch<unknown>(`/admin/stories/${id}/enqueue`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ preset, captions }),
+  });
+  return JobListSchema.parse(data).jobs;
+}
+
+export async function listJobs(params: { story_id?: number } = {}): Promise<Job[]> {
+  const search = new URLSearchParams();
+  if (params.story_id) {
+    search.set("story_id", String(params.story_id));
+  }
+  const qs = search.toString();
+  const data = await apiFetch<unknown>(`/admin/jobs${qs ? `?${qs}` : ""}`);
+  return z.array(JobSchema).parse(data);
+}
+
+const statusMap: Record<string, string> = {
+  queued: "Queued",
+  running: "Running",
+  done: "Done",
+  error: "Error",
+};
+
+export function mapJobStatus(status: string): string {
+  return statusMap[status] ?? "Unknown";
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.9)(react@19.1.0)
+      '@tanstack/react-query':
+        specifier: ^5
+        version: 5.85.0(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -926,6 +929,14 @@ packages:
 
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
+
+  '@tanstack/query-core@5.83.1':
+    resolution: {integrity: sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==}
+
+  '@tanstack/react-query@5.85.0':
+    resolution: {integrity: sha512-t1HMfToVMGfwEJRya6GG7gbK0luZJd+9IySFNePL1BforU1F3LqQ3tBC2Rpvr88bOrlU6PXyMLgJD0Yzn4ztUw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
@@ -3549,6 +3560,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.11
       postcss: 8.5.6
       tailwindcss: 4.1.11
+
+  '@tanstack/query-core@5.83.1': {}
+
+  '@tanstack/react-query@5.85.0(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.83.1
+      react: 19.1.0
 
   '@tybys/wasm-util@0.10.0':
     dependencies:


### PR DESCRIPTION
## Summary
- add EnqueueDialog and queue route to submit render jobs
- show job status with JobTable and React Query polling
- cover job status mapping with unit test and enqueue/job tracking with Playwright

## Testing
- `pnpm -F web test`
- `pnpm -F web e2e` *(fails: browser download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c940056588332bee23e7173049769