### PR TITLE
feat: add kanban board and shortcuts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # App
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 ADMIN_API_TOKEN=local-admin
+NEXT_PUBLIC_DEV_LOGGING=false
 API_BASE_URL=http://api:8000 # required by ingestor
 
 # DB/Queue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter web lint
+      - run: pnpm --filter web typecheck
+      - run: pnpm --filter web test
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm --filter web e2e
+      - run: pnpm --filter web build
+      - name: Secret scan
+        uses: gitleaks/gitleaks-action@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Monorepo for automating short-form dark storytelling videos.
 
+The web app now includes a `/board` Kanban view with drag-and-drop status updates and global keyboard shortcuts (`g i` for inbox, `g b` for board, `/` to focus search).
+
 ## Local POC Runbook
 
 1. **Prereqs**

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -10,3 +10,17 @@ This Next.js 15 app uses React 19, Tailwind CSS 4 and shadcn/ui.
 - `pnpm lint` – run ESLint with Prettier.
 - `pnpm test` – run unit tests with Vitest.
 - `pnpm e2e` – run Playwright end-to-end tests.
+- `pnpm typecheck` – run TypeScript without emitting output.
+
+## Features
+
+- `/board` Kanban board with drag-and-drop status updates.
+- Global shortcuts: `g i` (inbox), `g b` (board), `/` focuses the header search box.
+- Structured logs when `NEXT_PUBLIC_DEV_LOGGING=true`.
+
+Run Lighthouse against the board after building:
+
+```bash
+pnpm build && pnpm start &
+npx lighthouse http://localhost:3000/board --quiet --chrome-flags="--headless"
+```

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "e2e": "playwright test"
   },

--- a/apps/web/src/app/api/admin/jobs/data.ts
+++ b/apps/web/src/app/api/admin/jobs/data.ts
@@ -5,7 +5,7 @@ export interface JobData {
   status: string;
 }
 
-let jobs: JobData[] = [];
+const jobs: JobData[] = [];
 let nextId = 1;
 
 export function listJobs(story_id?: number): JobData[] {

--- a/apps/web/src/app/api/admin/stories/data.ts
+++ b/apps/web/src/app/api/admin/stories/data.ts
@@ -5,7 +5,7 @@ export interface StoryData {
   status: string;
 }
 
-let stories: StoryData[] = [
+const stories: StoryData[] = [
   { id: 1, title: "First story", body_md: "Hello", status: "pending" },
   {
     id: 2,

--- a/apps/web/src/app/board/page.tsx
+++ b/apps/web/src/app/board/page.tsx
@@ -1,0 +1,5 @@
+import KanbanBoard from "@/components/kanban-board";
+
+export default function BoardPage() {
+  return <KanbanBoard />;
+}

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,27 +1,50 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
+import KeyboardShortcuts from "./keyboard-shortcuts";
 
 export function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen grid grid-cols-[16rem_1fr]">
       <aside className="bg-zinc-900 text-zinc-100 p-4">
         <nav className="space-y-2">
-          <Link href="/" className="block hover:underline">
+          <Link
+            href="/"
+            className="block hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
             Home
           </Link>
-          <Link href="/dashboard" className="block hover:underline">
+          <Link
+            href="/dashboard"
+            className="block hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
             Dashboard
           </Link>
-          <Link href="/settings" className="block hover:underline">
+          <Link
+            href="/board"
+            className="block hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Board
+          </Link>
+          <Link
+            href="/settings"
+            className="block hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
             Settings
           </Link>
         </nav>
       </aside>
       <div className="flex flex-col bg-background text-foreground">
-        <header className="h-14 border-b border-zinc-800 flex items-center px-4">
+        <header className="h-14 border-b border-zinc-800 flex items-center px-4 gap-4">
           <span className="font-semibold">Dark Life</span>
+          <input
+            id="global-search"
+            type="search"
+            placeholder="Search"
+            className="ml-auto max-w-xs w-full rounded border border-input bg-background px-2 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
         </header>
         <main className="flex-1 p-4">{children}</main>
+        <KeyboardShortcuts />
       </div>
     </div>
   );

--- a/apps/web/src/components/kanban-board.tsx
+++ b/apps/web/src/components/kanban-board.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listStories, updateStoryStatus, type Story } from "@/lib/stories";
+import { logEvent } from "@/lib/log";
+
+const STATUSES = ["pending", "approved", "rejected"] as const;
+
+export default function KanbanBoard() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["stories"],
+    queryFn: () => listStories(),
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({ id, status }: { id: number; status: string }) =>
+      updateStoryStatus(id, status),
+    onMutate: async ({ id, status }) => {
+      await queryClient.cancelQueries({ queryKey: ["stories"] });
+      const previous = queryClient.getQueryData<Story[]>(["stories"]);
+      queryClient.setQueryData<Story[]>(["stories"], (old) =>
+        old ? old.map((s) => (s.id === id ? { ...s, status } : s)) : old,
+      );
+      logEvent("status_change", { id, status });
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(["stories"], ctx.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["stories"] });
+    },
+  });
+
+  if (isLoading) return <p>Loading...</p>;
+  if (isError) return <p>Failed to load stories.</p>;
+  const stories = data ?? [];
+  if (stories.length === 0) return <p>No stories.</p>;
+
+  return (
+    <div className="flex gap-4" data-testid="kanban-board">
+      {STATUSES.map((status) => (
+        <div
+          key={status}
+          className="flex-1 bg-muted p-2 rounded"
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => {
+            const id = Number(e.dataTransfer.getData("text/plain"));
+            if (id) {
+              mutation.mutate({ id, status });
+            }
+          }}
+        >
+          <h2 className="font-semibold mb-2 capitalize">{status}</h2>
+          <ul className="space-y-2 min-h-32">
+            {stories
+              .filter((s) => s.status === status)
+              .map((story) => (
+                <li key={story.id}>
+                  <div
+                    draggable
+                    onDragStart={(e) =>
+                      e.dataTransfer.setData("text/plain", String(story.id))
+                    }
+                    tabIndex={0}
+                    className="p-2 bg-background rounded shadow cursor-move focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {story.title}
+                  </div>
+                </li>
+              ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/keyboard-shortcuts.tsx
+++ b/apps/web/src/components/keyboard-shortcuts.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { logEvent } from "@/lib/log";
+
+export default function KeyboardShortcuts() {
+  const router = useRouter();
+  const awaiting = useRef(false);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "g") {
+        awaiting.current = true;
+        return;
+      }
+      if (awaiting.current) {
+        if (e.key === "i") {
+          router.push("/inbox");
+          logEvent("shortcut", { keys: "g i" });
+        } else if (e.key === "b") {
+          router.push("/board");
+          logEvent("shortcut", { keys: "g b" });
+        }
+        awaiting.current = false;
+        return;
+      }
+      if (e.key === "/") {
+        const input = document.getElementById("global-search") as HTMLInputElement | null;
+        if (input) {
+          e.preventDefault();
+          input.focus();
+          logEvent("shortcut", { keys: "/" });
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [router]);
+
+  return null;
+}

--- a/apps/web/src/lib/catalog.test.ts
+++ b/apps/web/src/lib/catalog.test.ts
@@ -10,6 +10,6 @@ describe("fetchCatalog", () => {
   it("returns mocked images", async () => {
     const images = await fetchCatalog();
     expect(images).toHaveLength(2);
-    expect(images[0].url).toBeDefined();
+    expect(images[0]!.url).toBeDefined();
   });
 });

--- a/apps/web/src/lib/log.ts
+++ b/apps/web/src/lib/log.ts
@@ -1,0 +1,4 @@
+export function logEvent(event: string, data: Record<string, unknown> = {}): void {
+  if (process.env.NEXT_PUBLIC_DEV_LOGGING !== "true") return;
+  console.log(JSON.stringify({ event, ...data }));
+}

--- a/apps/web/src/lib/split.test.ts
+++ b/apps/web/src/lib/split.test.ts
@@ -28,7 +28,7 @@ describe("splitSentences", () => {
     ];
     const parts = splitSentences(sentences, 2); // target 2 sec ~ 5 words
     expect(parts.length).toBe(3);
-    expect(parts[0].join(" ")).toContain("one");
-    expect(parts[2].join(" ")).toContain("seven");
+    expect(parts[0]!.join(" ")).toContain("one");
+    expect(parts[2]!.join(" ")).toContain("seven");
   });
 });

--- a/apps/web/src/lib/stories.test.ts
+++ b/apps/web/src/lib/stories.test.ts
@@ -7,7 +7,7 @@ describe("StorySchema", () => {
     expect(() => StorySchema.parse(data)).not.toThrow();
   });
   it("rejects invalid story", () => {
-    const data = { title: "t", status: "pending" } as any;
+    const data = { title: "t", status: "pending" } as unknown;
     expect(() => StorySchema.parse(data)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add `/board` Kanban page with drag-and-drop status updates
- wire up global keyboard shortcuts and structured logging
- add CI workflow for lint, typecheck, tests, build and secret scan

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `pnpm exec vitest run`
- `pnpm exec playwright install --with-deps` *(failed: HTTP 403)*
- `pnpm --filter web e2e` *(failed: Next.js route conflict)*
- `pnpm --filter web build` *(failed: route conflict)*
- `trufflehog --json file://$PWD`
- `npx -y lighthouse http://localhost:3000/board --quiet --chrome-flags="--headless" --output=json --output-path=/tmp/lh.json` *(failed: CHROME_PATH not set)*

------
https://chatgpt.com/codex/tasks/task_e_689c9e60ef3c833299eda7b0729b96e7