### PR TITLE
feat: add multi-stage Dockerfile for web app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ dist
 .git
 output
 .DS_Store
+.env

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+
+# Builder stage
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# install pnpm
+RUN npm install -g pnpm
+
+# copy dependency manifests
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/web/package.json apps/web/package.json
+
+# install dependencies for web workspace
+RUN pnpm install --frozen-lockfile --filter web...
+
+# copy source and build
+COPY . .
+RUN pnpm --filter web build
+
+# prune dev dependencies
+RUN pnpm prune --prod --filter web...
+
+# Runner stage
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+# install pnpm for runtime scripts
+RUN npm install -g pnpm
+ENV NODE_ENV=production
+
+# copy built application and production deps
+COPY --from=builder /app/apps/web/.next ./.next
+COPY --from=builder /app/apps/web/public ./public
+COPY --from=builder /app/apps/web/next.config.ts ./next.config.ts
+COPY --from=builder /app/apps/web/package.json ./package.json
+COPY --from=builder /app/node_modules ./node_modules
+
+# set runtime variables
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["pnpm", "start"]

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -46,9 +46,10 @@ services:
 
   web:
     build:
-      context: ../apps/web
-      dockerfile: Dockerfile
-    env_file: ../.env
+      context: ..
+      dockerfile: apps/web/Dockerfile
+    environment:
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## Summary
- create multi-stage Dockerfile for the web app using Node 22 and pnpm
- exclude `.env` from build context and pass API base URL at runtime
- update compose to use new Dockerfile and runtime env var

## Testing
- `docker build -f apps/web/Dockerfile .` *(fails: command not found)*
- `pnpm --filter web build` *(fails: duplicate route paths)*

------
https://chatgpt.com/codex/tasks/task_e_689ca6e2c7008332ac0fff6078ebe934