### PR TITLE
Expose Postgres port for local development

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-darklife}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s


### PR DESCRIPTION
## Summary
- expose Postgres 5432 port in docker compose for external access

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cbf5a96dc83328d42bfef58e01d1e