### PR TITLE
Add structured logging for renderer events

### DIFF
--- a/shared/logging.py
+++ b/shared/logging.py
@@ -20,3 +20,8 @@ def log_info(event: str, **fields: object) -> None:
 def log_error(event: str, **fields: object) -> None:
     """Emit an error JSON log line."""
     _log(logging.ERROR, event, **fields)
+
+
+def log_debug(event: str, **fields: object) -> None:
+    """Emit a debug-level JSON log line."""
+    _log(logging.DEBUG, event, **fields)


### PR DESCRIPTION
## Summary
- add `log_debug` helper for structured debug logs
- log start, poll, claim, heartbeat, and errors via shared helpers
- emit ffmpeg command at debug level and include job metadata in logs

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689cd2a26d408332911c468796994b13