### PR TITLE
chore(web): remove redundant route group

### DIFF
--- a/apps/web/src/app/(app)/story/[id]/split/page.tsx
+++ b/apps/web/src/app/(app)/story/[id]/split/page.tsx
@@ -1,7 +1,0 @@
-import SplitEditor from "@/components/SplitEditor";
-import { getStory } from "@/lib/stories";
-
-export default async function SplitPage({ params }: { params: { id: string } }) {
-  const story = await getStory(Number(params.id));
-  return <SplitEditor story={story} />;
-}


### PR DESCRIPTION
## Summary
- delete leftover `(app)` folder and duplicate `split` page

## Testing
- `pnpm -F web lint`
- `pnpm -F web test --run`


------
https://chatgpt.com/codex/tasks/task_e_689cd409587083328ad809642e5f72f5