### PR TITLE
Handle preflight errors and render job timeouts

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -100,6 +100,10 @@ class Settings(BaseSettings):
         default=120,
         description="Lease duration when claiming render jobs",
     )
+    JOB_TIMEOUT_SEC: int = Field(
+        default=600,
+        description="Maximum seconds a render job may run before timing out",
+    )
 
     # Compatibility attribute; ``ADMIN_API_TOKEN`` is retained as a property
     # so existing code referencing it continues to function. The backing


### PR DESCRIPTION
## Summary
- post API errors when preflight or ffmpeg fail in slideshow renderer
- track lease expiry and enforce job timeouts in render job runner
- add configurable job timeout setting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cfcde6a9483329c75b76f768dd79b