### PR TITLE
Add renderer tests for logging, failures, and audio output

### DIFF
--- a/tests/renderer/test_job_runner_logging.py
+++ b/tests/renderer/test_job_runner_logging.py
@@ -1,0 +1,88 @@
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from shared.config import settings
+from video_renderer import render_job_runner as runner
+
+
+def test_poll_logs_queue_depth_and_paths(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+
+    # Stub HTTP client
+    jobs = [{"id": "j1", "story_id": "s1", "part_id": "p1", "lease_seconds": 10}]
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            return None
+
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params):
+            return DummyResp(jobs)
+
+        async def post(self, url, json=None):
+            # claim and status posts
+            return DummyResp({"lease_expires_at": "2020-01-01T00:00:00Z"})
+
+    monkeypatch.setattr(runner.httpx, "AsyncClient", lambda *a, **k: DummyClient())
+
+    # Avoid running actual job processing
+    async def fake_run_job(client, job, sem, lease_expires_at=None):
+        return None
+
+    monkeypatch.setattr(runner, "_run_job", fake_run_job)
+
+    # Force default paths
+    monkeypatch.setattr(settings, "CONTENT_DIR", Path("/content"))
+    monkeypatch.setattr(settings, "MUSIC_DIR", Path("/content/audio/music"))
+    monkeypatch.setattr(settings, "OUTPUT_DIR", Path("/output"))
+    monkeypatch.setattr(settings, "API_BASE_URL", "http://api")
+    monkeypatch.setattr(settings, "API_AUTH_TOKEN", "t")
+    monkeypatch.setattr(settings, "POLL_INTERVAL_MS", 10)
+    monkeypatch.setattr(settings, "MAX_CLAIM", 1)
+
+    # Stop after first sleep
+    async def cancel_sleep(_):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(runner.asyncio, "sleep", cancel_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(runner._poll_loop())
+
+    # Extract logs
+    start_log = json.loads(caplog.records[0].message)
+    poll_log = json.loads(caplog.records[1].message)
+    claim_log = json.loads(caplog.records[2].message)
+
+    # Default paths
+    assert start_log["content_dir"] == "/content"
+    assert start_log["music_dir"] == "/content/audio/music"
+    assert start_log["output_dir"] == "/output"
+
+    # queue depth
+    assert poll_log["event"] == "poll"
+    assert poll_log["queue_depth"] == 1
+    assert poll_log["service"] == "renderer"
+
+    # claim log required fields
+    assert claim_log["event"] == "claim"
+    assert claim_log["job_id"] == "j1"
+    assert claim_log["story_id"] == "s1"
+    assert claim_log["part_id"] == "p1"
+    assert claim_log["service"] == "renderer"

--- a/tests/renderer/test_render_failures.py
+++ b/tests/renderer/test_render_failures.py
@@ -1,0 +1,44 @@
+import types
+from pathlib import Path
+
+import pytest
+
+from shared.config import settings
+from video_renderer import create_slideshow as cs
+
+
+def test_ffmpeg_failure_posts_snippet(monkeypatch, tmp_path):
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    (frames_dir / "f1.png").write_bytes(b"x")
+
+    music_dir = tmp_path / "music"
+    music_dir.mkdir()
+    (music_dir / "track.mp3").write_bytes(b"x")
+
+    monkeypatch.setattr(settings, "MUSIC_DIR", music_dir)
+    monkeypatch.setattr(settings, "OUTPUT_DIR", tmp_path / "out")
+    monkeypatch.setattr(settings, "TMP_DIR", tmp_path / "tmp")
+    monkeypatch.setattr(settings, "API_BASE_URL", "http://api")
+
+    sent = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        sent["url"] = url
+        sent["json"] = json
+        return types.SimpleNamespace()
+
+    monkeypatch.setattr(cs.httpx, "post", fake_post)
+
+    class FakeProc:
+        returncode = 1
+        stderr = b"missing frames or audio"
+        stdout = b""
+
+    monkeypatch.setattr(cs.subprocess, "run", lambda *a, **k: FakeProc())
+
+    with pytest.raises(cs.RenderError):
+        cs.render("job1", "s1", "p1", frames_dir)
+
+    assert sent["json"]["status"] == "errored"
+    assert "missing frames" in sent["json"]["stderr_snippet"]

--- a/tests/renderer/test_render_output.py
+++ b/tests/renderer/test_render_output.py
@@ -1,0 +1,86 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from shared.config import settings
+from video_renderer import create_slideshow as cs
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg required")
+def test_render_writes_atomic_output_with_audio(tmp_path, monkeypatch):
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    # generate two simple png frames
+    subprocess.run([
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=red:s=160x120:d=1",
+        "-frames:v",
+        "1",
+        str(frames_dir / "f1.png"),
+    ], check=True)
+    subprocess.run([
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=blue:s=160x120:d=1",
+        "-frames:v",
+        "1",
+        str(frames_dir / "f2.png"),
+    ], check=True)
+
+    music_dir = tmp_path / "music"
+    music_dir.mkdir()
+    subprocess.run([
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=1000:duration=1",
+        "-q:a",
+        "9",
+        "-acodec",
+        "libmp3lame",
+        str(music_dir / "track.mp3"),
+    ], check=True)
+
+    out_dir = tmp_path / "out"
+    tmp_dir = tmp_path / "tmp"
+    out_dir.mkdir()
+
+    monkeypatch.setattr(settings, "MUSIC_DIR", music_dir)
+    monkeypatch.setattr(settings, "OUTPUT_DIR", out_dir)
+    monkeypatch.setattr(settings, "TMP_DIR", tmp_dir)
+
+    meta = cs.render("job1", "story", "p1", frames_dir)
+    out_path = Path(meta["path"])
+    assert out_path.exists()
+    assert out_path.stat().st_size > 0
+    # temp file removed
+    assert not (tmp_dir / "job1" / "story_p1.mp4").exists()
+
+    # audio stream check
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            str(out_path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    assert "audio" in probe.stdout


### PR DESCRIPTION
## Summary
- test polling worker logs queue depth, default paths, and required fields
- ensure ffmpeg failures send stderr snippet and errored status
- confirm rendered output uses atomic rename, has audio stream, and non-zero size

## Testing
- `pytest tests/renderer -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689da2254fb48332a776238401dfdd1c