### PR TITLE
Add render job leasing and state machine API

### DIFF
--- a/apps/api/alembic/versions/0003_job_lease_and_error_fields.py
+++ b/apps/api/alembic/versions/0003_job_lease_and_error_fields.py
@@ -1,0 +1,30 @@
+"""Add lease and error tracking fields to jobs."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003_job_lease_and_error_fields"
+down_revision = "0002_reddit_fetch_state"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "jobs", sa.Column("retries", sa.Integer(), server_default="0", nullable=False)
+    )
+    op.add_column("jobs", sa.Column("error_class", sa.Text(), nullable=True))
+    op.add_column("jobs", sa.Column("error_message", sa.Text(), nullable=True))
+    op.add_column("jobs", sa.Column("stderr_snippet", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "stderr_snippet")
+    op.drop_column("jobs", "error_message")
+    op.drop_column("jobs", "error_class")
+    op.drop_column("jobs", "retries")
+    op.drop_column("jobs", "lease_expires_at")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -14,6 +14,7 @@ from .jobs import router as jobs_router
 from .reddit_admin import router as reddit_admin_router
 from .admin_stories import router as admin_stories_router
 from .render import router as render_router
+from .render_jobs import router as render_jobs_router
 
 
 logging.basicConfig(level=logging.INFO)
@@ -46,6 +47,7 @@ app.include_router(jobs_router)
 app.include_router(reddit_admin_router)
 app.include_router(admin_stories_router)
 app.include_router(render_router)
+app.include_router(render_jobs_router)
 
 
 @app.on_event("startup")

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -148,6 +148,13 @@ class Job(SQLModel, table=True):
     story_id: int | None = Field(default=None, foreign_key="story.id")
     kind: str
     status: str
+    lease_expires_at: datetime | None = Field(
+        default=None, sa_column=Column(DateTime(timezone=True))
+    )
+    retries: int = 0
+    error_class: str | None = None
+    error_message: str | None = None
+    stderr_snippet: str | None = None
     payload: dict | None = Field(default=None, sa_column=Column(JSON))
     result: dict | None = Field(default=None, sa_column=Column(JSON))
     created_at: datetime | None = Field(

--- a/apps/api/render_jobs.py
+++ b/apps/api/render_jobs.py
@@ -1,0 +1,108 @@
+"""API router for render jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import SQLModel, Session, select
+
+from .db import get_session
+from .models import Job
+
+LEASE_SECONDS = 180
+
+router = APIRouter(prefix="/render-jobs", tags=["render-jobs"])
+
+
+@router.get("/", response_model=list[Job])
+def list_render_jobs(
+    status: Optional[str] = None,
+    limit: int = 100,
+    session: Session = Depends(get_session),
+) -> list[Job]:
+    query = select(Job).where(Job.kind == "render_part")
+    if status:
+        query = query.where(Job.status == status)
+    query = query.order_by(Job.id).limit(limit)
+    return session.exec(query).all()
+
+
+@router.post("/{job_id}/claim")
+def claim_render_job(job_id: int, session: Session = Depends(get_session)) -> dict:
+    job = session.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.status != "queued":
+        raise HTTPException(status_code=409, detail="Invalid state")
+    job.status = "claimed"
+    job.lease_expires_at = datetime.now(timezone.utc) + timedelta(seconds=LEASE_SECONDS)
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return {"lease_expires_at": job.lease_expires_at}
+
+
+@router.post("/{job_id}/heartbeat")
+def heartbeat_render_job(job_id: int, session: Session = Depends(get_session)) -> dict:
+    job = session.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.status not in {"claimed", "rendering"}:
+        raise HTTPException(status_code=409, detail="Invalid state")
+    job.lease_expires_at = datetime.now(timezone.utc) + timedelta(seconds=LEASE_SECONDS)
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return {"lease_expires_at": job.lease_expires_at}
+
+
+class RenderJobStatusUpdate(SQLModel):
+    status: str
+    artifact_path: str | None = None
+    bytes: int | None = None
+    duration_ms: int | None = None
+    error_class: str | None = None
+    error_message: str | None = None
+    stderr_snippet: str | None = None
+
+
+@router.post("/{job_id}/status", response_model=Job)
+def update_render_job_status(
+    job_id: int,
+    update: RenderJobStatusUpdate,
+    session: Session = Depends(get_session),
+) -> Job:
+    job = session.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    valid_next = {
+        "queued": {"claimed"},
+        "claimed": {"rendering"},
+        "rendering": {"rendered", "errored"},
+    }
+    if update.status not in valid_next.get(job.status, set()):
+        raise HTTPException(status_code=409, detail="Invalid state transition")
+    job.status = update.status
+    if update.artifact_path or update.bytes is not None or update.duration_ms is not None:
+        job.result = job.result or {}
+        if update.artifact_path is not None:
+            job.result["artifact_path"] = update.artifact_path
+        if update.bytes is not None:
+            job.result["bytes"] = update.bytes
+        if update.duration_ms is not None:
+            job.result["duration_ms"] = update.duration_ms
+    if update.error_class is not None:
+        job.error_class = update.error_class
+    if update.error_message is not None:
+        job.error_message = update.error_message
+    if update.stderr_snippet is not None:
+        job.stderr_snippet = update.stderr_snippet
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+__all__ = ["router"]

--- a/tests/api/test_render_jobs_api.py
+++ b/tests/api/test_render_jobs_api.py
@@ -1,0 +1,88 @@
+import datetime as dt
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel, Session, create_engine
+
+from apps.api.main import app
+from apps.api.db import get_session
+from apps.api.models import Job
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def get_test_session():
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+    with TestClient(app) as client:
+        yield client, engine
+    app.dependency_overrides.clear()
+
+
+def _create_job(session: Session) -> int:
+    job = Job(kind="render_part", status="queued")
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job.id
+
+
+def test_claim_concurrency(client):
+    client, engine = client
+    with Session(engine) as session:
+        job_id = _create_job(session)
+
+    res1 = client.post(f"/render-jobs/{job_id}/claim")
+    assert res1.status_code == 200
+    res2 = client.post(f"/render-jobs/{job_id}/claim")
+    assert res2.status_code == 409
+
+
+def test_heartbeat_extends_lease(client):
+    client, engine = client
+    with Session(engine) as session:
+        job_id = _create_job(session)
+
+    res = client.post(f"/render-jobs/{job_id}/claim")
+    lease1 = dt.datetime.fromisoformat(res.json()["lease_expires_at"])
+    res = client.post(f"/render-jobs/{job_id}/heartbeat")
+    lease2 = dt.datetime.fromisoformat(res.json()["lease_expires_at"])
+    assert lease2 > lease1
+
+
+def test_state_machine_transitions(client):
+    client, engine = client
+    with Session(engine) as session:
+        job_id = _create_job(session)
+
+    # Heartbeat before claim should fail
+    res = client.post(f"/render-jobs/{job_id}/heartbeat")
+    assert res.status_code == 409
+
+    # Claim
+    res = client.post(f"/render-jobs/{job_id}/claim")
+    assert res.status_code == 200
+
+    # Directly finishing without rendering should fail
+    res = client.post(f"/render-jobs/{job_id}/status", json={"status": "rendered"})
+    assert res.status_code == 409
+
+    # Move to rendering then rendered
+    res = client.post(f"/render-jobs/{job_id}/status", json={"status": "rendering"})
+    assert res.status_code == 200
+    res = client.post(f"/render-jobs/{job_id}/status", json={"status": "rendered"})
+    assert res.status_code == 200
+
+    # Claiming again should fail
+    res = client.post(f"/render-jobs/{job_id}/claim")
+    assert res.status_code == 409

--- a/tests/test_renderer_poller.py
+++ b/tests/test_renderer_poller.py
@@ -17,7 +17,7 @@ def test_poller_processes_series(tmp_path, monkeypatch):
         ],
     }
 
-    def fake_get(url, timeout):
+    def fake_get(url, timeout, headers=None):
         class Resp:
             def __init__(self, content: bytes = b"", data=None):
                 self.content = content
@@ -35,7 +35,7 @@ def test_poller_processes_series(tmp_path, monkeypatch):
 
     patch_calls = []
 
-    def fake_patch(url, json, timeout):
+    def fake_patch(url, json, timeout, headers=None):
         patch_calls.append((url, json))
         class Resp:
             def raise_for_status(self):


### PR DESCRIPTION
## Summary
- add leasing and error tracking fields to Job model and migration
- implement render job endpoints for listing, claiming, heartbeats, and status updates with state machine validation
- add tests covering concurrency, lease renewal, and transition rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689dd20a34a083328f4b05e71057833e