### PR TITLE
feat: add background music selection and ducked mixdown

### DIFF
--- a/services/renderer/__init__.py
+++ b/services/renderer/__init__.py
@@ -1,5 +1,5 @@
 """Renderer service components."""
 
-from . import subtitles, tts
+from . import music, subtitles, tts
 
-__all__ = ["tts", "subtitles"]
+__all__ = ["tts", "subtitles", "music"]

--- a/services/renderer/music.py
+++ b/services/renderer/music.py
@@ -1,0 +1,100 @@
+"""Background music selection and mixing utilities."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from shared.config import settings
+from shared.logging import log_error, log_info
+
+
+def _list_tracks() -> list[Path]:
+    """Return sorted list of available mp3 tracks."""
+    music_dir = Path(settings.MUSIC_DIR)
+    return sorted(music_dir.glob("*.mp3"))
+
+
+def select_track(selection: str | None = None, *, required: bool = False) -> Path | None:
+    """Select a music track based on ``selection`` policy.
+
+    ``selection`` may be ``"named:<filename>"`` to choose a specific file or
+    ``None``/``"first"`` to return the first sorted ``*.mp3`` file. When
+    ``required`` is True, a missing track raises :class:`FileNotFoundError` and
+    an error is logged.
+    """
+
+    tracks = _list_tracks()
+    music_dir = Path(settings.MUSIC_DIR)
+    if not tracks:
+        if required:
+            log_error("music_missing", music_dir=str(music_dir))
+            raise FileNotFoundError(f"no .mp3 tracks in {music_dir}")
+        return None
+
+    chosen: Path | None = None
+    if selection and selection.startswith("named:"):
+        target = selection.split(":", 1)[1]
+        for t in tracks:
+            if t.name == target:
+                chosen = t
+                break
+        if not chosen:
+            log_error("music_named_missing", name=target, music_dir=str(music_dir))
+            if required:
+                raise FileNotFoundError(f"named track not found: {target}")
+            return None
+    else:
+        chosen = tracks[0]
+
+    log_info(
+        "music_select",
+        chosen_track=chosen.name,
+        policy=selection or "first",
+        music_dir=str(music_dir),
+    )
+    return chosen
+
+
+def mix(voice: Path, music: Path | None, out_path: Path) -> Path:
+    """Mix ``voice`` and ``music`` using ffmpeg with sidechain compression."""
+
+    if music is None:
+        shutil.copyfile(voice, out_path)
+        return out_path
+
+    threshold = 0.000976563
+    filter_complex = (
+        f"[1:a]volume={settings.MUSIC_GAIN_DB}dB[m];"
+        f"[m][0:a]sidechaincompress=threshold={threshold}:ratio=20:attack=5:release=50[d];"
+        f"[0:a][d]amix=inputs=2:duration=first:dropout_transition=2,volume=-1dB[out]"
+    )
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(voice),
+        "-i",
+        str(music),
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[out]",
+        "-c:a",
+        "pcm_s16le",
+        str(out_path),
+    ]
+
+    try:
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except Exception as exc:  # pragma: no cover - ffmpeg missing
+        log_error("ffmpeg", cmd=" ".join(cmd), error=str(exc))
+        raise
+
+    log_info("music_mix", voice=str(voice), music=str(music), out=str(out_path))
+    return out_path
+
+
+__all__ = ["select_track", "mix"]

--- a/shared/config.py
+++ b/shared/config.py
@@ -105,6 +105,16 @@ class Settings(BaseSettings):
         description="Maximum seconds a render job may run before timing out",
     )
 
+    # Background music mix configuration
+    MUSIC_GAIN_DB: float = Field(
+        default=-3.0,
+        description="Baseline gain applied to music tracks in dB",
+    )
+    DUCKING_DB: float = Field(
+        default=-12.0,
+        description="Additional attenuation applied to music when voice is present",
+    )
+
     # ElevenLabs TTS configuration
     ELEVENLABS_API_KEY: str = Field(
         default="",

--- a/tests/renderer/test_music.py
+++ b/tests/renderer/test_music.py
@@ -1,0 +1,87 @@
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from services.renderer import music
+from shared.config import settings
+
+
+def test_select_track_policy(tmp_path, monkeypatch):
+    music_dir = tmp_path / "music"
+    music_dir.mkdir()
+    (music_dir / "b.mp3").write_bytes(b"b")
+    (music_dir / "a.mp3").write_bytes(b"a")
+    monkeypatch.setattr(settings, "MUSIC_DIR", music_dir)
+
+    track = music.select_track(required=True)
+    assert track.name == "a.mp3"
+
+    track = music.select_track("named:b.mp3", required=True)
+    assert track.name == "b.mp3"
+
+    with pytest.raises(FileNotFoundError):
+        music.select_track("named:nope.mp3", required=True)
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg required")
+def test_mix_ducking(tmp_path, monkeypatch):
+    voice = tmp_path / "voice.wav"
+    music_src = tmp_path / "music.mp3"
+    out = tmp_path / "mix.wav"
+
+    subprocess.run([
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:duration=1",
+        "-f",
+        "lavfi",
+        "-i",
+        "anullsrc=r=44100:cl=mono:d=1",
+        "-filter_complex",
+        "[0]volume=18dB[a];[a][1]concat=n=2:v=0:a=1",
+        str(voice),
+    ],
+        check=True,
+    )
+
+    subprocess.run([
+        "ffmpeg", "-f", "lavfi", "-i", "sine=frequency=880:duration=2", "-q:a", "9", "-acodec", "libmp3lame", str(music_src)
+    ], check=True)
+
+    monkeypatch.setattr(settings, "MUSIC_GAIN_DB", -3.0)
+    monkeypatch.setattr(settings, "DUCKING_DB", -12.0)
+
+    music.mix(voice, music_src, out)
+    assert out.exists()
+
+    def max_vol(
+        path: Path,
+        start: float | None = None,
+        dur: float | None = None,
+        bandpass: bool = False,
+    ) -> float:
+        cmd = ["ffmpeg", "-hide_banner"]
+        if start is not None:
+            cmd += ["-ss", str(start)]
+        if dur is not None:
+            cmd += ["-t", str(dur)]
+        filter_chain = "volumedetect"
+        if bandpass:
+            filter_chain = "bandpass=f=880:width_type=h:width=100,volumedetect"
+        cmd += ["-i", str(path), "-af", filter_chain, "-f", "null", "-"]
+        res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True)
+        m = re.search(r"max_volume: ([\-0-9\.]+) dB", res.stdout)
+        assert m, res.stdout
+        return float(m.group(1))
+
+    peak = max_vol(out)
+    assert peak < -1.0
+
+    orig = max_vol(music_src, bandpass=True)
+    ducked = max_vol(out, 0.2, 0.5, bandpass=True)
+    assert orig - ducked > 5.0


### PR DESCRIPTION
## Summary
- add MUSIC_GAIN_DB and DUCKING_DB settings
- implement music selection and ducked mixdown with ffmpeg sidechaincompress
- cover selection policy and mix behavior with tests

## Testing
- `python -m pytest tests/renderer/test_music.py::test_select_track_policy -q`
- `python -m pytest tests/renderer/test_music.py::test_mix_ducking -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689df12ae89083328d2ead7ac1e0065f