### PR TITLE
Implement ffmpeg muxer with atomic output and tests

### DIFF
--- a/services/renderer/__init__.py
+++ b/services/renderer/__init__.py
@@ -1,5 +1,5 @@
 """Renderer service components."""
 
-from . import music, subtitles, tts
+from . import ffmpeg, music, subtitles, tts
 
-__all__ = ["tts", "subtitles", "music"]
+__all__ = ["tts", "subtitles", "music", "ffmpeg"]

--- a/services/renderer/ffmpeg.py
+++ b/services/renderer/ffmpeg.py
@@ -1,0 +1,73 @@
+"""FFmpeg-based muxing with atomic output and error handling."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from shared.config import settings
+from shared.logging import log_debug, log_error, log_info
+
+
+def mux(video: Path, audio: Path, name: str) -> Path:
+    """Mux ``video`` and ``audio`` into ``OUTPUT_DIR/<name>.mp4``.
+
+    Writes to ``{OUTPUT_DIR}/.tmp`` first, fsyncs, then atomically renames.
+    Raises ``FileNotFoundError`` if inputs are missing and ``RuntimeError`` on
+    ffmpeg failures with stderr snippet logged.
+    """
+
+    if not video.exists():
+        raise FileNotFoundError(video)
+    if not audio.exists():
+        raise FileNotFoundError(audio)
+
+    out_dir = settings.OUTPUT_DIR
+    tmp_dir = out_dir / ".tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = tmp_dir / f"{name}.mp4"
+    out_path = out_dir / f"{name}.mp4"
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video),
+        "-i",
+        str(audio),
+        "-map",
+        "0:v:0",
+        "-map",
+        "1:a:0",
+        "-c:v",
+        "copy",
+        "-c:a",
+        "aac",
+        "-shortest",
+        str(tmp_path),
+    ]
+
+    env = os.environ.copy()
+    if os.getenv("DEBUG", "false").lower() == "true":
+        ffreport = settings.TMP_DIR / f"ffreport-{name}.log"
+        ffreport.parent.mkdir(parents=True, exist_ok=True)
+        env["FFREPORT"] = f"file={ffreport}:level=32"
+        log_info("ffreport", path=str(ffreport))
+
+    log_debug("ffmpeg_cmd", argv=cmd)
+
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
+        with open(tmp_path, "rb") as fh:
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, out_path)
+        return out_path
+    except subprocess.CalledProcessError as exc:
+        snippet = (exc.stderr or "")[:200]
+        log_error("ffmpeg_fail", exit_code=exc.returncode, stderr=snippet)
+        tmp_path.unlink(missing_ok=True)
+        raise RuntimeError("ffmpeg failed") from exc
+
+
+__all__ = ["mux"]

--- a/tests/renderer/test_ffmpeg.py
+++ b/tests/renderer/test_ffmpeg.py
@@ -1,0 +1,90 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from services.renderer import ffmpeg
+from shared.config import settings
+
+
+def test_missing_inputs(tmp_path, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    monkeypatch.setattr(settings, "OUTPUT_DIR", out_dir)
+
+    video = tmp_path / "v.mp4"
+    audio = tmp_path / "a.wav"
+    with pytest.raises(FileNotFoundError):
+        ffmpeg.mux(video, audio, "clip")
+
+    tmp_dir = out_dir / ".tmp"
+    assert not tmp_dir.exists() or list(tmp_dir.iterdir()) == []
+
+
+def test_error_propagation_logs_and_cleans(tmp_path, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    monkeypatch.setattr(settings, "OUTPUT_DIR", out_dir)
+
+    video = tmp_path / "v.mp4"
+    audio = tmp_path / "a.wav"
+    video.write_text("v")
+    audio.write_text("a")
+
+    logs: dict[str, object] = {}
+
+    def fake_log_error(event: str, **fields: object) -> None:
+        logs.update({"event": event, **fields})
+
+    monkeypatch.setattr(ffmpeg, "log_error", fake_log_error)
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0], stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError):
+        ffmpeg.mux(video, audio, "clip")
+
+    assert logs["exit_code"] == 1
+    assert "boom" in str(logs["stderr"])
+    tmp_dir = out_dir / ".tmp"
+    assert tmp_dir.exists()
+    assert list(tmp_dir.iterdir()) == []
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg required")
+def test_no_orphan_tmp_files(tmp_path, monkeypatch):
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    monkeypatch.setattr(settings, "OUTPUT_DIR", out_dir)
+
+    video = tmp_path / "v.mp4"
+    audio = tmp_path / "a.wav"
+
+    subprocess.run([
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=black:s=16x16:d=1",
+        str(video),
+    ], check=True)
+    subprocess.run([
+        "ffmpeg",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=440:duration=1",
+        "-acodec",
+        "pcm_s16le",
+        str(audio),
+    ], check=True)
+
+    out = ffmpeg.mux(video, audio, "clip")
+    assert out.exists()
+
+    tmp_dir = out_dir / ".tmp"
+    assert tmp_dir.exists()
+    assert list(tmp_dir.iterdir()) == []


### PR DESCRIPTION
## Summary
- add ffmpeg muxer that writes to OUTPUT_DIR/.tmp, fsyncs, renames atomically, and logs FFREPORT when DEBUG
- export new ffmpeg module
- test missing inputs, ffmpeg errors, and temp cleanup

## Testing
- `pytest tests/renderer/test_ffmpeg.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dfa50647c8332b2807e345969ee57