### PR TITLE
feat: add structured logging with secret masking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,19 @@ jobs:
         run: "! grep -R 'ADMIN_API_TOKEN\|ELEVENLABS_API_KEY\|API_AUTH_TOKEN' apps/web/.next"
       - name: Secret scan
         uses: gitleaks/gitleaks-action@v2
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install . pytest httpx
+      - name: Run tests
+        run: |
+          API_AUTH_TOKEN=sekrit ELEVENLABS_API_KEY=apikey pytest -q | tee pytest.log
+      - name: Ensure secrets not logged
+        run: "! grep -R 'sekrit\|apikey' pytest.log"

--- a/services/renderer/Dockerfile
+++ b/services/renderer/Dockerfile
@@ -25,10 +25,11 @@ COPY video_renderer /app/video_renderer
 ENV PYTHONPATH=/app \
     WHISPER_MODEL=base \
     OUTPUT_DIR=/output \
-    TMPDIR=/tmp/render
+    TMPDIR=/tmp/render \
+    PYTHONUNBUFFERED=1
 
 VOLUME ["/output"]
 
-CMD ["python", "services/renderer/poller.py"]
+CMD ["python", "-u", "services/renderer/poller.py"]
 
 HEALTHCHECK CMD python -c "exit(0)"

--- a/shared/logging.py
+++ b/shared/logging.py
@@ -1,15 +1,49 @@
 from __future__ import annotations
 
-"""Structured logging helpers for renderer services."""
+"""Structured JSON logging for renderer services.
+
+Logs are emitted as single-line JSON objects. Secrets such as
+``API_AUTH_TOKEN`` or ``ELEVENLABS_API_KEY`` are masked before logging.
+"""
 
 import json
 import logging
+import os
+from typing import Any
+
+from shared.config import settings
+
 
 SERVICE_NAME = "renderer"
 
+# Configure root logger for JSON output. Only the JSON message body is printed.
+_LEVEL = getattr(logging, os.getenv("LOG_LEVEL", settings.LOG_LEVEL).upper(), logging.INFO)
+logging.basicConfig(level=_LEVEL, format="%(message)s")
+
+_SECRET_KEYS = {"API_AUTH_TOKEN", "ELEVENLABS_API_KEY"}
+
+
+def _current_secrets() -> list[str]:
+    return [settings.API_AUTH_TOKEN, settings.ELEVENLABS_API_KEY]
+
+
+def _mask(value: Any) -> Any:
+    """Replace occurrences of known secret values with ``[MASKED]``."""
+    if isinstance(value, str):
+        for secret in _current_secrets():
+            if secret and secret in value:
+                value = value.replace(secret, "[MASKED]")
+    return value
+
 
 def _log(level: int, event: str, **fields: object) -> None:
-    logging.log(level, json.dumps({"service": SERVICE_NAME, "event": event, **fields}))
+    data: dict[str, Any] = {"service": SERVICE_NAME, "event": event}
+    for key, value in fields.items():
+        if key in _SECRET_KEYS:
+            data[key] = "[MASKED]"
+        else:
+            data[key] = _mask(value)
+    logging.log(level, json.dumps(data))
 
 
 def log_info(event: str, **fields: object) -> None:
@@ -25,3 +59,7 @@ def log_error(event: str, **fields: object) -> None:
 def log_debug(event: str, **fields: object) -> None:
     """Emit a debug-level JSON log line."""
     _log(logging.DEBUG, event, **fields)
+
+
+__all__ = ["log_info", "log_error", "log_debug", "SERVICE_NAME"]
+

--- a/tests/renderer/test_job_runner_logging.py
+++ b/tests/renderer/test_job_runner_logging.py
@@ -52,7 +52,7 @@ def test_poll_logs_queue_depth_and_paths(monkeypatch, caplog):
     monkeypatch.setattr(settings, "MUSIC_DIR", Path("/content/audio/music"))
     monkeypatch.setattr(settings, "OUTPUT_DIR", Path("/output"))
     monkeypatch.setattr(settings, "API_BASE_URL", "http://api")
-    monkeypatch.setattr(settings, "API_AUTH_TOKEN", "t")
+    monkeypatch.setattr(settings, "API_AUTH_TOKEN", "sekrittoken")
     monkeypatch.setattr(settings, "POLL_INTERVAL_MS", 10)
     monkeypatch.setattr(settings, "MAX_CLAIM", 1)
 

--- a/tests/renderer/test_logging_mask.py
+++ b/tests/renderer/test_logging_mask.py
@@ -1,0 +1,23 @@
+import json
+import logging
+
+from shared.config import settings
+from shared.logging import log_info
+
+
+def test_log_masks_secrets(monkeypatch, caplog):
+    """Ensure secret tokens are not emitted in log entries."""
+
+    monkeypatch.setattr(settings, "API_AUTH_TOKEN", "sekrit")
+    monkeypatch.setattr(settings, "ELEVENLABS_API_KEY", "apikey")
+
+    caplog.set_level(logging.INFO)
+    log_info("test", api_token=settings.API_AUTH_TOKEN, other=settings.ELEVENLABS_API_KEY)
+
+    record = caplog.records[0]
+    msg = json.loads(record.message)
+    assert msg["api_token"] == "[MASKED]"
+    assert msg["other"] == "[MASKED]"
+    assert "sekrit" not in record.message
+    assert "apikey" not in record.message
+

--- a/video_renderer/render_job_runner.py
+++ b/video_renderer/render_job_runner.py
@@ -170,10 +170,11 @@ async def _run_job(
         else:
             lease_deadline = [time.time() + lease_sec]
 
+        # Heartbeat every 5-10 seconds to maintain lease and report progress
+        interval = max(lease_sec / 2, 5)
+        interval = min(interval, 10)
         hb_task = asyncio.create_task(
-            _heartbeat(
-                client, job_id, story_id, part_id, max(lease_sec / 2, 5), lease_deadline
-            )
+            _heartbeat(client, job_id, story_id, part_id, interval, lease_deadline)
         )
         job_deadline = time.time() + settings.JOB_TIMEOUT_SEC
         job_task = (


### PR DESCRIPTION
## Summary
- log using JSON with root configuration and secret masking
- send render heartbeats every 5-10s
- add Python CI job verifying secrets stay masked

## Testing
- `pytest`
- `API_AUTH_TOKEN=sekrit ELEVENLABS_API_KEY=apikey pytest -q`
- `grep -R 'sekrit\|apikey' /tmp/pytest_secret.log && echo notfound`


------
https://chatgpt.com/codex/tasks/task_e_689dfcddbce48332a3281ab68dcb27be