### PR TITLE
chore: refine renderer compose service

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -67,15 +67,32 @@ services:
     build:
       context: ..
       dockerfile: services/renderer/Dockerfile
+    command: python -u services/renderer/poller.py
     env_file: ../.env
+    environment:
+      PYTHONPATH: /app
+      PYTHONUNBUFFERED: "1"
     volumes:
+      - ../content:/content:ro
       - ../output:/output
-      - ../content:/content
+      - ../content/tts_cache:/content/tts_cache
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     depends_on:
       api:
         condition: service_healthy
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-m", "services.renderer.healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    profiles:
+      - renderer
 
   uploader:
     build:


### PR DESCRIPTION
## Summary
- run renderer worker via unbuffered Python poller
- mount host content, output and cache directories with log rotation
- add healthcheck and profile flag for renderer service

## Testing
- `docker-compose up renderer` *(fails: Error while fetching server API version: FileNotFoundError(2, 'No such file or directory'))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689e038bcad083329b2076bb3f2a66d8