### PR TITLE
feat: enforce ingestion idempotency with backoff

### DIFF
--- a/apps/api/alembic/versions/0004_story_source_external_index.py
+++ b/apps/api/alembic/versions/0004_story_source_external_index.py
@@ -1,0 +1,22 @@
+"""Add unique index on (source, external_id)"""
+
+from alembic import op
+
+revision = "0004_story_source_external_index"
+down_revision = "0003_job_lease_and_error_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("uq_story_source_external", "story", type_="unique")
+    op.create_index(
+        "ix_story_source_external", "story", ["source", "external_id"], unique=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_story_source_external", table_name="story")
+    op.create_unique_constraint(
+        "uq_story_source_external", "story", ["source", "external_id"]
+    )

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -42,7 +42,7 @@ class Story(StoryBase, table=True):
     )
 
     __table_args__ = (
-        UniqueConstraint("source", "external_id", name="uq_story_source_external"),
+        Index("ix_story_source_external", "source", "external_id", unique=True),
     )
 
 

--- a/tests/api/test_admin_stories_endpoint.py
+++ b/tests/api/test_admin_stories_endpoint.py
@@ -56,6 +56,25 @@ def test_upsert_story_logs_request(client: TestClient, caplog: pytest.LogCapture
         for r in caplog.records
     )
 
-    # upsert should return 200 on duplicate
+    # duplicate should return 409
+    res2 = client.post("/admin/stories", json=payload, headers=headers)
+    assert res2.status_code == 409
+
+
+def test_upsert_story_updates(client: TestClient):
+    payload = {
+        "external_id": "abc123",
+        "source": "reddit",
+        "title": "Test",
+        "author": "me",
+        "created_utc": 0,
+        "text": "hello",
+    }
+    headers = {"Authorization": "Bearer token"}
+    res = client.post("/admin/stories", json=payload, headers=headers)
+    assert res.status_code == 201
+
+    payload["title"] = "New Title"
     res2 = client.post("/admin/stories", json=payload, headers=headers)
     assert res2.status_code == 200
+    assert res2.json()["title"] == "New Title"

--- a/tests/services/test_incremental_checkpoint.py
+++ b/tests/services/test_incremental_checkpoint.py
@@ -1,0 +1,73 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from services.reddit_ingestor import incremental
+
+
+class DummyClient:
+    def __init__(self, posts):
+        self.posts = posts
+
+    def fetch_new_posts(self, subreddit, after=None, limit=100):
+        return self.posts, None
+
+
+class Normalized:
+    def __init__(self, title, body):
+        self.title = title
+        self.body = body
+        self.language = "en"
+        self.nsfw = False
+        self.hash_title_body = "h"
+
+
+def make_post(pid, created):
+    return {
+        "id": pid,
+        "name": f"t3_{pid}",
+        "title": pid,
+        "selftext": "body",
+        "created_utc": created,
+        "ups": 1,
+        "num_comments": 0,
+        "author": "a",
+        "is_self": True,
+        "url": "",
+    }
+
+
+def test_fetch_incremental_checkpoint(monkeypatch):
+    state = {"fullname": None, "created": None}
+
+    def fake_load(sub):
+        return state["fullname"], state["created"]
+
+    def fake_update(sub, fullname, created):
+        state["fullname"] = fullname
+        state["created"] = created
+
+    inserted = []
+
+    def fake_insert(payload):
+        inserted.append(payload["reddit_id"])
+        return True
+
+    monkeypatch.setattr(incremental, "_load_fetch_state", fake_load)
+    monkeypatch.setattr(incremental, "_update_fetch_state", fake_update)
+    monkeypatch.setattr(incremental, "insert_post", fake_insert)
+    monkeypatch.setattr(incremental, "normalize_post", lambda p: (Normalized(p["title"], p["selftext"]), None))
+    monkeypatch.setattr(incremental, "extract_image_urls", lambda p: [])
+    monkeypatch.setattr(incremental, "push_new_story", lambda p: None)
+    monkeypatch.setattr(incremental.time, "sleep", lambda s: None)
+
+    now = int(datetime.now(tz=timezone.utc).timestamp())
+    posts1 = [make_post("p2", now), make_post("p1", now - 1)]
+    client1 = DummyClient(posts1)
+    incremental.fetch_incremental("test", client=client1)
+    assert inserted == ["t3_p2", "t3_p1"]
+
+    posts2 = [make_post("p3", now + 1), make_post("p2", now)]
+    client2 = DummyClient(posts2)
+    incremental.fetch_incremental("test", client=client2)
+    assert inserted == ["t3_p2", "t3_p1", "t3_p3"]

--- a/tests/services/test_storage_backoff.py
+++ b/tests/services/test_storage_backoff.py
@@ -1,0 +1,78 @@
+import pytest
+
+from services.reddit_ingestor.storage import insert_post
+from shared.config import settings
+
+
+def _payload():
+    return {
+        "reddit_id": "t3_123",
+        "title": "Hello",
+        "author": "alice",
+        "created_utc": 0,
+        "selftext": "body",
+        "url": "http://example.com",
+        "nsfw": False,
+    }
+
+
+def test_insert_post_retries_on_429(monkeypatch):
+    settings.API_BASE_URL = "http://api"
+    settings.API_AUTH_TOKEN = "token"
+
+    calls = []
+
+    class Resp:
+        def __init__(self, status, headers=None):
+            self.status_code = status
+            self.headers = headers or {}
+
+    responses = iter([
+        Resp(429, {"Retry-After": "1"}),
+        Resp(201),
+    ])
+
+    def fake_post(url, json, headers, timeout):
+        calls.append(url)
+        return next(responses)
+
+    sleep_calls = []
+    monkeypatch.setattr(
+        "services.reddit_ingestor.storage.requests.post", fake_post
+    )
+    monkeypatch.setattr(
+        "services.reddit_ingestor.storage.time.sleep", lambda s: sleep_calls.append(s)
+    )
+
+    assert insert_post(_payload()) is True
+    assert sleep_calls == [1.0]
+    assert len(calls) == 2
+
+
+def test_insert_post_retries_on_500(monkeypatch):
+    settings.API_BASE_URL = "http://api"
+    settings.API_AUTH_TOKEN = "token"
+
+    class Resp:
+        def __init__(self, status):
+            self.status_code = status
+            self.headers = {}
+
+    responses = iter([Resp(500), Resp(201)])
+
+    def fake_post(url, json, headers, timeout):
+        return next(responses)
+
+    sleep_calls = []
+    monkeypatch.setattr(
+        "services.reddit_ingestor.storage.requests.post", fake_post
+    )
+    monkeypatch.setattr(
+        "services.reddit_ingestor.storage.random.uniform", lambda a, b: 0
+    )
+    monkeypatch.setattr(
+        "services.reddit_ingestor.storage.time.sleep", lambda s: sleep_calls.append(s)
+    )
+
+    assert insert_post(_payload()) is True
+    assert sleep_calls == [1]


### PR DESCRIPTION
## Summary
- ensure stories have unique `(source, external_id)` index
- add upsert-or-skip endpoints for stories and subreddit checkpoints
- add jittered polling and exponential backoff for ingestion requests
- test duplicate handling, retry/backoff logic, and checkpoint recovery

## Testing
- `pytest tests/api/test_admin_stories_endpoint.py tests/services/test_storage_insert_post.py tests/services/test_storage_backoff.py tests/services/test_incremental_checkpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_689e062ff6bc83328dc986942f6bb892