### PR TITLE
Enforce story part bounds and add preview API

### DIFF
--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -83,6 +83,8 @@ class StoryPart(SQLModel, table=True):
     index: int
     body_md: str
     est_seconds: int
+    start_char: int = 0
+    end_char: int = 0
     created_at: datetime | None = Field(
         sa_column=Column(DateTime(timezone=True), server_default=func.now())
     )
@@ -100,6 +102,8 @@ class StoryPartRead(SQLModel):
     index: int
     body_md: str
     est_seconds: int
+    start_char: int
+    end_char: int
 
 
 class Asset(SQLModel, table=True):

--- a/tests/api/test_stories_endpoints.py
+++ b/tests/api/test_stories_endpoints.py
@@ -99,12 +99,12 @@ def test_get_images_unranked_last(client: TestClient, monkeypatch: pytest.Monkey
 
 
 def test_split_endpoint_creates_parts(client: TestClient):
-    body = " ".join([f"Sentence {i}." for i in range(20)])
+    body = " ".join([f"Sentence {i}." for i in range(120)])
     story = client.post(
         "/stories", json={"title": "Split", "body_md": body}
     ).json()
 
-    res = client.post(f"/stories/{story['id']}/split", params={"target_seconds": 5})
+    res = client.post(f"/stories/{story['id']}/split", params={"target_seconds": 60})
     assert res.status_code == 200
     parts = res.json()
     assert len(parts) >= 2
@@ -112,7 +112,7 @@ def test_split_endpoint_creates_parts(client: TestClient):
 
 
 def test_enqueue_series_creates_jobs(client: TestClient, monkeypatch: pytest.MonkeyPatch):
-    body = "Sentence one. Sentence two. Sentence three."
+    body = " ".join([f"Sentence {i}." for i in range(120)])
     story = client.post(
         "/stories", json={"title": "Full", "body_md": body}
     ).json()
@@ -136,7 +136,7 @@ def test_enqueue_series_creates_jobs(client: TestClient, monkeypatch: pytest.Mon
     assert res.status_code == 200
 
     parts = client.post(
-        f"/stories/{story['id']}/split", params={"target_seconds": 10}
+        f"/stories/{story['id']}/split", params={"target_seconds": 60}
     ).json()
 
     res = client.post(f"/stories/{story['id']}/enqueue-series")

--- a/tests/api/test_story_part_invalid.py
+++ b/tests/api/test_story_part_invalid.py
@@ -1,0 +1,54 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from sqlalchemy.pool import StaticPool
+
+from apps.api.main import app
+from apps.api.db import get_session
+from apps.api.stories import CHARS_PER_SECOND, MIN_PART_SECONDS, MAX_PART_SECONDS
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def get_test_session():
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+def test_replace_parts_rejects_out_of_bounds(client: TestClient):
+    min_chars = int(CHARS_PER_SECOND * MIN_PART_SECONDS) - 10
+    max_chars = int(CHARS_PER_SECOND * MAX_PART_SECONDS) + 10
+    short_sentence = "a" * min_chars + "."
+    long_sentence = "b" * max_chars + "."
+    body = short_sentence + " " + long_sentence
+
+    story = client.post(
+        "/stories", json={"title": "bad", "body_md": body}
+    ).json()
+
+    # too short
+    res = client.put(
+        f"/stories/{story['id']}/parts",
+        json=[{"start_char": 0, "end_char": len(short_sentence)}],
+    )
+    assert res.status_code == 400
+
+    # too long
+    res = client.put(
+        f"/stories/{story['id']}/parts",
+        json=[{"start_char": len(short_sentence) + 1, "end_char": len(body)}],
+    )
+    assert res.status_code == 400
+

--- a/tests/test_stories_api.py
+++ b/tests/test_stories_api.py
@@ -61,9 +61,12 @@ def test_pagination(client: TestClient):
 
 
 def test_split_story_parts_order(client: TestClient):
-    body = " ".join([
-        ("word " * 10 + f"sentence {i}.").strip() for i in range(5)
-    ])
+    body = " ".join(
+        [
+            ("word " * 50 + f"sentence {i}.").strip()
+            for i in range(20)
+        ]
+    )
     story = create_story(client, "Split me", "approved")
     res = client.patch(
         f"/stories/{story['id']}", json={"body_md": body}
@@ -71,17 +74,17 @@ def test_split_story_parts_order(client: TestClient):
     assert res.status_code == 200
 
     res = client.post(
-        f"/stories/{story['id']}/split", params={"target_seconds": 15}
+        f"/stories/{story['id']}/split", params={"target_seconds": 60}
     )
     assert res.status_code == 200
     parts = res.json()
-    assert len(parts) == 2
-    assert [p["index"] for p in parts] == [1, 2]
+    assert len(parts) >= 2
+    assert [p["index"] for p in parts] == list(range(1, len(parts) + 1))
     # ensure ordering of sentences
     first_part_text = parts[0]["body_md"]
-    second_part_text = parts[1]["body_md"]
+    last_part_text = parts[-1]["body_md"]
     assert "sentence 0" in first_part_text
-    assert "sentence 4" in second_part_text
+    assert "sentence 19" in last_part_text
 
 
 def test_extract_keywords_matches_domain_list():

--- a/tests/test_story_part_utils.py
+++ b/tests/test_story_part_utils.py
@@ -1,0 +1,18 @@
+from apps.api.stories import (
+    _snap_boundaries,
+    _estimate_seconds,
+    CHARS_PER_SECOND,
+)
+
+
+def test_snap_boundaries_expands_to_sentence():
+    text = "First sentence. Second one here. Third!"
+    start, end = _snap_boundaries(text, 17, 25)
+    assert text[start:end] == "Second one here."
+
+
+def test_estimate_seconds_char_heuristic():
+    length = int(CHARS_PER_SECOND * 2)
+    text = "x" * length
+    assert _estimate_seconds(text) == 2
+


### PR DESCRIPTION
## Summary
- enforce 30-75s bounds when splitting stories and store character offsets
- add preview and replace endpoints using char-based duration estimates
- provide tests for boundary snapping, estimator, and invalid part submissions

## Testing
- `pytest tests/test_story_part_utils.py tests/api/test_story_part_invalid.py tests/api/test_stories_endpoints.py tests/test_stories_api.py -q`
- `pytest tests/api/test_render_endpoint.py::test_next_series_marks_running tests/test_story_part_utils.py tests/api/test_story_part_invalid.py tests/api/test_stories_endpoints.py tests/test_stories_api.py -q`
- `pytest tests/test_renderer_poller.py::test_process_job_happy_path tests/test_renderer_poller.py::test_abort_on_lease_loss -q`


------
https://chatgpt.com/codex/tasks/task_e_689e29b706a8833296d7113557f909c4